### PR TITLE
Add AGENTS guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,18 @@
+# AGENTS Guidelines
+
+These instructions apply to the entire repository.
+
+## Code Style
+- Adhere to PEP8 formatting for Python code.
+- Use descriptive names and include docstrings for new public functions or classes.
+- Group imports by standard library, third-party, and local modules.
+
+## Testing
+- Run `pytest` to execute the test suite before committing changes.
+
+## Documentation
+- Update relevant documentation when altering functionality or adding features.
+
+## Commit Messages
+- Write clear, concise commit messages that explain the intent of the changes.
+


### PR DESCRIPTION
## Summary
- add AGENTS.md with repository-wide instructions

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'src'; ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68a2b1b9a58883288720240be874f4f8