### PR TITLE
Replace python-graphml with NetworkX-based shim and update deps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,18 @@
+# AGENTS Guidelines
+
+These instructions apply to the entire repository.
+
+## Code Style
+- Adhere to PEP8 formatting for Python code.
+- Use descriptive names and include docstrings for new public functions or classes.
+- Group imports by standard library, third-party, and local modules.
+
+## Testing
+- Run `pytest` to execute the test suite before committing changes.
+
+## Documentation
+- Update relevant documentation when altering functionality or adding features.
+
+## Commit Messages
+- Write clear, concise commit messages that explain the intent of the changes.
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,22 +1,24 @@
 # Core dependencies
-asyncio
 pydantic>=2.0
 protobuf>=4.0
 pyyaml
-numpy>=1.24.0
+numpy>=1.26.0
 networkx>=3.0
 
 # Vector storage and embeddings
-faiss-cpu>=1.7.4
+faiss-cpu>=1.12.0
 chromadb>=0.4.0
 sentence-transformers>=2.2.0
 
 # ML and evolution
-scikit-learn>=1.3.0
-scipy>=1.10.0
+scikit-learn>=1.4.0
+scipy>=1.12.0
+
 
 # Graph export
-python-graphml>=1.0
+lxml>=4.9            # GraphML writer backend used by networkx
+hiredis>=2.3         # Faster Redis protocol parser
+orjson>=3.9          # Fast JSON in hot paths
 
 # Testing
 pytest>=7.0

--- a/src/python_graphml.py
+++ b/src/python_graphml.py
@@ -1,0 +1,45 @@
+"""
+Compat shim for legacy ``python_graphml`` usages.
+
+This module proxies read and write operations to NetworkX's GraphML
+helpers backed by ``lxml``. It allows older imports such as
+``import python_graphml`` to remain functional after the dependency was
+removed.
+"""
+
+from __future__ import annotations
+
+import networkx as nx
+from typing import Any
+
+
+def write_graph(graph: Any, path: str, **kwargs: Any) -> None:
+    """Write ``graph`` to ``path`` in GraphML format.
+
+    Parameters
+    ----------
+    graph:
+        A NetworkX graph instance to serialise.
+    path:
+        Destination file path.
+    **kwargs:
+        Additional keyword arguments forwarded to ``nx.write_graphml``.
+    """
+
+    nx.write_graphml(graph, path, **kwargs)
+
+
+def read_graph(path: str, **kwargs: Any) -> Any:
+    """Read a GraphML file located at ``path`` into a NetworkX graph."""
+
+    return nx.read_graphml(path, **kwargs)
+
+
+# Older code may call ``write``/``read`` directly.
+def write(graph: Any, path: str, **kwargs: Any) -> None:
+    write_graph(graph, path, **kwargs)
+
+
+def read(path: str, **kwargs: Any) -> Any:
+    return read_graph(path, **kwargs)
+


### PR DESCRIPTION
## Summary
- drop nonexistent `python-graphml` dependency and add lxml, hiredis, and orjson
- bump numpy, faiss-cpu, scikit-learn, and scipy versions
- provide `src/python_graphml.py` shim backed by NetworkX

## Testing
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'chromadb')*

------
https://chatgpt.com/codex/tasks/task_e_68a2b1b9a58883288720240be874f4f8