### PR TITLE
Replace python-graphml with NetworkX-based shim and update deps

### DIFF
--- a/src/core/event_bus.py
+++ b/src/core/event_bus.py
@@ -122,7 +122,11 @@ class EventBus:
         self._serializer = Serializer()
         self._redis_enabled = _EVENTBUS_REDIS
         self._redis_channel = _EVENTBUS_CHANNEL
-        self.redis_client = redis.from_url(_REDIS_URL, decode_responses=_REDIS_DECODE)
+        try:
+            self.redis_client = redis.from_url(_REDIS_URL, decode_responses=_REDIS_DECODE)
+        except Exception as e:
+            logging.error(f"Failed to connect to Redis at {_REDIS_URL}: {e}")
+            raise RuntimeError(f"Could not connect to Redis at {_REDIS_URL}. Please check your Redis server and connection settings.") from e
         self.pubsub = None
         self._redis_listener_task: Optional[asyncio.Task] = None
     


### PR DESCRIPTION
## Summary
- drop nonexistent `python-graphml` dependency and add lxml, hiredis, and orjson
- provide NetworkX-based `python_graphml` compatibility shim
- prefer `orjson` for byte-efficient serialization and bridge the `EventBus` with Redis pub/sub
- expand `bench_pubsub.py` to support publish-only and round-trip throughput modes

## Testing
- `pip install -r requirements.txt` *(fails: Operation cancelled by user after large package downloads)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'src'; ModuleNotFoundError: No module named 'numpy')*
- `python scripts/bench_pubsub.py N=10` *(fails: ModuleNotFoundError: No module named 'redis')*

------
https://chatgpt.com/codex/tasks/task_e_68a2b1b9a58883288720240be874f4f8