### PR TITLE
Add active inference planning option

### DIFF
--- a/cortex/config/flags.py
+++ b/cortex/config/flags.py
@@ -34,6 +34,9 @@ class PlannerFlags:
     use_ladder_router: bool = _env_bool("CORTEX_USE_LADDER_ROUTER", True)
     ladder_llm_decompose: bool = _env_bool("CORTEX_LADDER_LLM_DECOMPOSE", False)
     ladder_shadow_mode: bool = _env_bool("CORTEX_LADDER_SHADOW_MODE", True)
+    ladder_active_inference: bool = _env_bool(
+        "CORTEX_LADDER_ACTIVE_INFERENCE", False
+    )
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## Summary
- introduce a generative state model and free-energy minimization to adjust task energies during planning
- add PlannerFlags.ladder_active_inference to toggle active-inference behaviour
- cover active-inference energy adjustment with unit test

## Testing
- `pytest tests/planner/test_ladder_enhanced.py::TestEnhancedLadderPlanner::test_active_inference_energy_minimization -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8c6d34ab48328a51b0385fd69db02