### PR TITLE
REUG runtime: green tests, e2e stream, resilient emitter

### DIFF
--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -12,6 +12,10 @@
    - `REUG_TOOL_REGISTRY_DIR`
    - `REUG_MAX_TOOL_CALLS`, `REUG_EXEC_TIMEOUT_S`, `REUG_EXEC_MAX_RETRIES`
 
+   If `REUG_EVENTBUS` is unset or a Redis backend is unavailable, the runtime
+   gracefully falls back to appending JSONL telemetry under
+   `./logs/events/events.jsonl`.
+
    If `.env` is missing:
 
    ```bash


### PR DESCRIPTION
## Summary
- document JSONL event logging fallback when Redis is absent
- runtime verified via smoke and full tests

## How to Run
```bash
make env && make deps && uvicorn app:app --port 8080
```

## Redis Optionality
If `REUG_EVENTBUS` is unset or Redis is unreachable, telemetry is appended to `./logs/events/events.jsonl`.

## Streaming Example
```bash
curl -sS -X POST http://localhost:8080/v1/chat/stream \
  -H "Content-Type: application/json" \
  -d '{"message":"say hello using the echo tool","session_id":"codex"}'
```

------
https://chatgpt.com/codex/tasks/task_e_68a974e929088328951107dd7ee941fd