### PR TITLE
runtime: document core modules

### DIFF
--- a/src/reug_runtime/config.py
+++ b/src/reug_runtime/config.py
@@ -1,13 +1,40 @@
+"""Configuration utilities for the REUG runtime.
+
+This module centralizes environment driven settings and exposes a small
+``Settings`` dataclass that other modules can rely on.  All helpers use a
+predictable ``_getenv`` pattern and include Google style docstrings so the
+expected arguments and return types are explicit.
+"""
+
 import os
 from dataclasses import dataclass
 
 
 def _getenv(name: str, default: str | None = None) -> str | None:
+    """Return the value of an environment variable.
+
+    Args:
+        name: Name of the environment variable to read.
+        default: Value returned when the variable is not set.
+
+    Returns:
+        The string value stored in the environment or ``default`` when the
+        variable is missing.
+    """
     v = os.getenv(name, default)
     return v
 
 
 def _getenv_float(name: str, default: float) -> float:
+    """Retrieve a floating point environment variable.
+
+    Args:
+        name: Environment variable name.
+        default: Fallback value when the variable is unset or invalid.
+
+    Returns:
+        The parsed floating point value or ``default`` if conversion fails.
+    """
     try:
         return float(os.getenv(name, str(default)))
     except Exception:
@@ -15,6 +42,15 @@ def _getenv_float(name: str, default: float) -> float:
 
 
 def _getenv_int(name: str, default: int) -> int:
+    """Retrieve an integer environment variable.
+
+    Args:
+        name: Environment variable name.
+        default: Fallback value when the variable is unset or invalid.
+
+    Returns:
+        The parsed integer value or ``default`` if conversion fails.
+    """
     try:
         return int(os.getenv(name, str(default)))
     except Exception:
@@ -22,6 +58,20 @@ def _getenv_int(name: str, default: int) -> int:
 
 
 def _getenv_bool(name: str, default: bool) -> bool:
+    """Retrieve a boolean environment variable.
+
+    The function interprets a number of common truthy strings
+    (``"1"``, ``"true"``, ``"yes"``, ``"on"``) as ``True``. All other values
+    result in ``False``.
+
+    Args:
+        name: Environment variable name.
+        default: Fallback value when the variable is unset.
+
+    Returns:
+        ``True`` or ``False`` depending on the variable content, or ``default``
+        if the variable is missing.
+    """
     v = os.getenv(name)
     if v is None:
         return default
@@ -30,6 +80,19 @@ def _getenv_bool(name: str, default: bool) -> bool:
 
 @dataclass(slots=True)
 class Settings:
+    """Runtime configuration resolved from environment variables.
+
+    Attributes:
+        max_tool_calls: Maximum number of tool invocations per turn.
+        tool_timeout_s: Timeout for a single tool execution in seconds.
+        model_stream_timeout_s: Timeout for model streaming in seconds.
+        max_retries: Number of retry attempts after the initial try.
+        retry_base_ms: Base delay in milliseconds used for exponential backoff.
+        schema_enforce: Whether to enforce tool input schemas.
+        event_log_dir: Optional directory for event log storage.
+        tool_registry_dir: Optional directory for tool registration artifacts.
+    """
+
     # Execution limits / guardrails
     max_tool_calls: int = _getenv_int("REUG_MAX_TOOL_CALLS", 5)
     tool_timeout_s: float = _getenv_float("REUG_EXEC_TIMEOUT_S", 20.0)

--- a/tests/runtime/test_docstrings.py
+++ b/tests/runtime/test_docstrings.py
@@ -1,0 +1,24 @@
+import inspect
+
+from reug_runtime.config import _getenv
+from reug_runtime.router import execute_turn
+from reug_runtime.router_tools import reug_start_turn
+
+
+def _assert_google_doc(func, sections):
+    doc = inspect.getdoc(func)
+    assert doc is not None, f"{func.__name__} missing docstring"
+    for sec in sections:
+        assert f"{sec}:" in doc, f"{func.__name__} docstring missing '{sec}:' section"
+
+
+def test_config_getenv_docstring():
+    _assert_google_doc(_getenv, ["Args", "Returns"])
+
+
+def test_router_execute_turn_docstring():
+    _assert_google_doc(execute_turn, ["Args", "Yields"])
+
+
+def test_router_tools_start_turn_docstring():
+    _assert_google_doc(reug_start_turn, ["Args", "Returns"])


### PR DESCRIPTION
## Summary
- document REUG settings helpers and runtime orchestrator with Google-style docstrings
- expand router tool endpoints with docstrings for each handler
- add tests that assert critical functions expose Args/Returns sections

## Changes
- add module and function docstrings across `reug_runtime` modules
- verify docstring presence via `tests/runtime/test_docstrings.py`

## Verification
- `pre-commit run --all-files`
- `pytest -q tests/runtime`

## Runtime impact
- no changes to execution; documentation only

## Observability
- no new events or fields

## Rollback
- revert this PR to remove docstring and test additions

------
https://chatgpt.com/codex/tasks/task_e_68aa0846c2ec8328be4f9eb410b83554