### PR TITLE
cortex: harden adapter and add policy gating

### DIFF
--- a/src/core/utils/__init__.py
+++ b/src/core/utils/__init__.py
@@ -1,0 +1,13 @@
+from .hash_utils import sha256_json, normalize_text, blake2b_hexdigest
+from .redaction import redact_prompt_and_context
+from .circuit_breaker import CircuitBreaker
+from .cooldown import CooldownLRU
+
+__all__ = [
+    "sha256_json",
+    "normalize_text",
+    "blake2b_hexdigest",
+    "redact_prompt_and_context",
+    "CircuitBreaker",
+    "CooldownLRU",
+]

--- a/src/core/utils/circuit_breaker.py
+++ b/src/core/utils/circuit_breaker.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import time
+
+
+class CircuitBreaker:
+    """
+    Simple circuit breaker.
+    - failure_threshold: failures in window to open
+    - recovery_timeout: seconds to half-open
+    """
+
+    def __init__(self, failure_threshold: int = 5, recovery_timeout: float = 30.0):
+        self.failure_threshold = failure_threshold
+        self.recovery_timeout = recovery_timeout
+        self.failures = 0
+        self.state = "closed"  # closed, open, half_open
+        self.open_until = 0.0
+
+    def allowed(self) -> bool:
+        now = time.time()
+        if self.state == "open":
+            if now >= self.open_until:
+                self.state = "half_open"
+                return True
+            return False
+        return True
+
+    def on_success(self) -> None:
+        self.failures = 0
+        self.state = "closed"
+
+    def on_failure(self) -> None:
+        self.failures += 1
+        if self.failures >= self.failure_threshold:
+            self.state = "open"
+            self.open_until = time.time() + self.recovery_timeout
+
+    def is_open(self) -> bool:
+        return self.state == "open"

--- a/src/core/utils/cooldown.py
+++ b/src/core/utils/cooldown.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import time
+from collections import OrderedDict
+from typing import Optional
+
+
+class CooldownLRU:
+    """
+    Small LRU-style cooldown cache.
+    Tracks last-hit timestamp per key; returns True if within cooldown.
+    """
+
+    def __init__(self, maxsize: int = 1024, ttl_seconds: float = 300.0):
+        self.maxsize = maxsize
+        self.ttl = ttl_seconds
+        self._store: OrderedDict[str, float] = OrderedDict()
+
+    def _prune(self) -> None:
+        now = time.time()
+        to_del = [k for k, ts in self._store.items() if (now - ts) > self.ttl]
+        for k in to_del:
+            self._store.pop(k, None)
+        while len(self._store) > self.maxsize:
+            self._store.popitem(last=False)
+
+    def hit(self, key: str) -> bool:
+        """
+        Record a hit and return True if it's within cooldown (i.e., should skip).
+        """
+        now = time.time()
+        prev = self._store.get(key)
+        self._store[key] = now
+        self._store.move_to_end(key, last=True)
+        self._prune()
+        if prev is None:
+            return False
+        return (now - prev) < self.ttl

--- a/src/core/utils/hash_utils.py
+++ b/src/core/utils/hash_utils.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+
+_WS = re.compile(r"\s+")
+_PUNC = re.compile(r"[^\w\s]", flags=re.UNICODE)
+
+
+def normalize_text(text: str) -> str:
+    """Lowercase, trim, collapse spaces, remove punctuation."""
+    if not isinstance(text, str):
+        text = str(text)
+    t = text.lower().strip()
+    t = _PUNC.sub(" ", t)
+    t = _WS.sub(" ", t)
+    return t.strip()
+
+
+def blake2b_hexdigest(text: str) -> str:
+    return hashlib.blake2b(text.encode("utf-8"), digest_size=32).hexdigest()
+
+
+def sha256_json(obj) -> str:
+    """Stable SHA256 over canonical JSON."""
+    data = json.dumps(obj, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(data.encode("utf-8")).hexdigest()

--- a/src/core/utils/redaction.py
+++ b/src/core/utils/redaction.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, Tuple
+
+EMAIL = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
+HEX32PLUS = re.compile(r"\b[0-9a-fA-F]{32,}\b")
+KEYWORDS = re.compile(r"(api[_-]?key|secret|token|password)\s*[:=]\s*([^\s,;]+)", re.IGNORECASE)
+
+
+def _mask(s: str) -> str:
+    if not s or len(s) < 6:
+        return "•••"
+    return s[:3] + "…" + s[-3:]
+
+
+def _redact_str(s: str) -> Tuple[str, Dict[str, int]]:
+    hits = {"email": 0, "hex": 0, "keyword": 0}
+
+    def _repl_email(m):
+        hits["email"] += 1
+        return _mask(m.group(0))
+
+    def _repl_hex(m):
+        hits["hex"] += 1
+        return _mask(m.group(0))
+
+    def _repl_kw(m):
+        hits["keyword"] += 1
+        return f"{m.group(1)}={_mask(m.group(2))}"
+
+    s = EMAIL.sub(_repl_email, s)
+    s = HEX32PLUS.sub(_repl_hex, s)
+    s = KEYWORDS.sub(_repl_kw, s)
+    return s, hits
+
+
+def _walk(obj):
+    if isinstance(obj, dict):
+        return {k: _walk(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_walk(v) for v in obj]
+    if isinstance(obj, str):
+        red, _ = _redact_str(obj)
+        return red
+    return obj
+
+
+def redact_prompt_and_context(prompt: str, context: Dict[str, Any]) -> Tuple[str, Dict[str, Any], Dict[str, Any]]:
+    """Redact sensitive patterns. Returns (prompt_redacted, context_redacted, report)."""
+    red_prompt, hits_p = _redact_str(prompt or "")
+    red_ctx = _walk(context or {})
+    report = {"prompt_redactions": hits_p}
+    return red_prompt, red_ctx, report

--- a/src/orchestration/__init__.py
+++ b/src/orchestration/__init__.py
@@ -1,1 +1,7 @@
-"""Orchestration module for deterministic planner → router → dispatcher flow."""
+from .cortex_weaning import (
+    TrainingPhase,
+    PhaseConfig,
+    CortexWeaningOrchestrator,
+)
+
+__all__ = ["TrainingPhase", "PhaseConfig", "CortexWeaningOrchestrator"]

--- a/src/orchestration/cortex_weaning.py
+++ b/src/orchestration/cortex_weaning.py
@@ -1,31 +1,111 @@
 from __future__ import annotations
 
-"""Basic orchestrator for determining cortex usage phases."""
-
 from enum import Enum
-from typing import Any, Dict
+from dataclasses import dataclass
+from typing import Any, Dict, List
 
 
-class WeaningPhase(Enum):
-    FULL = "full"
-    PARTIAL = "partial"
+class TrainingPhase(Enum):
+    BOOTSTRAP = "bootstrap"
+    GUIDED = "guided"
+    SUPERVISED = "supervised"
     AUTONOMOUS = "autonomous"
 
 
+@dataclass
+class PhaseConfig:
+    cortex_intervention_threshold: float
+    self_attempt_first: bool
+    cortex_confidence_requirement: float
+    knowledge_validation_required: bool
+
+
 class CortexWeaningOrchestrator:
+    """Manages progressive reduction of cortex dependency."""
+
     def __init__(self) -> None:
-        self.current_phase = WeaningPhase.FULL
+        self.current_phase = TrainingPhase.BOOTSTRAP
+        self.window_scores: List[float] = []
+        self.window_size = 20
+        self.hysteresis = 0.05
+        self.min_sustain = 3
+        self.phase_configs: Dict[TrainingPhase, PhaseConfig] = {
+            TrainingPhase.BOOTSTRAP: PhaseConfig(
+                cortex_intervention_threshold=0.8,
+                self_attempt_first=False,
+                cortex_confidence_requirement=0.6,
+                knowledge_validation_required=False,
+            ),
+            TrainingPhase.GUIDED: PhaseConfig(
+                cortex_intervention_threshold=0.5,
+                self_attempt_first=True,
+                cortex_confidence_requirement=0.7,
+                knowledge_validation_required=True,
+            ),
+            TrainingPhase.SUPERVISED: PhaseConfig(
+                cortex_intervention_threshold=0.3,
+                self_attempt_first=True,
+                cortex_confidence_requirement=0.8,
+                knowledge_validation_required=True,
+            ),
+            TrainingPhase.AUTONOMOUS: PhaseConfig(
+                cortex_intervention_threshold=0.1,
+                self_attempt_first=True,
+                cortex_confidence_requirement=0.9,
+                knowledge_validation_required=True,
+            ),
+        }
+
+    async def should_use_cortex(self, confidence: float, context: Dict[str, Any]) -> bool:
+        cfg = self.phase_configs[self.current_phase]
+        return confidence < cfg.cortex_intervention_threshold
 
     async def advance_phase_if_ready(self, autonomy_score: float) -> bool:
-        if self.current_phase == WeaningPhase.FULL and autonomy_score > 0.8:
-            self.current_phase = WeaningPhase.PARTIAL
-            return True
-        if self.current_phase == WeaningPhase.PARTIAL and autonomy_score > 0.95:
-            self.current_phase = WeaningPhase.AUTONOMOUS
+        self._push_score(autonomy_score)
+        thresholds = {
+            TrainingPhase.BOOTSTRAP: 0.30,
+            TrainingPhase.GUIDED: 0.50,
+            TrainingPhase.SUPERVISED: 0.70,
+            TrainingPhase.AUTONOMOUS: 0.85,
+        }
+        t_current = thresholds.get(self.current_phase, 1.0)
+        if self._sustained_at_or_above(t_current + self.hysteresis):
+            phases = list(TrainingPhase)
+            idx = phases.index(self.current_phase)
+            if idx < len(phases) - 1:
+                self.current_phase = phases[idx + 1]
+                return True
+        return False
+
+    async def maybe_demote_phase(self) -> bool:
+        thresholds = {
+            TrainingPhase.BOOTSTRAP: 0.0,
+            TrainingPhase.GUIDED: 0.30,
+            TrainingPhase.SUPERVISED: 0.50,
+            TrainingPhase.AUTONOMOUS: 0.70,
+        }
+        phases = list(TrainingPhase)
+        idx = phases.index(self.current_phase)
+        if idx == 0:
+            return False
+        lower_phase = phases[idx - 1]
+        t_lower = thresholds[self.current_phase]
+        if self._sustained_below(t_lower - self.hysteresis):
+            self.current_phase = lower_phase
             return True
         return False
 
-    async def should_use_cortex(self, confidence: float, context: Dict[str, Any]) -> bool:
-        if self.current_phase == WeaningPhase.AUTONOMOUS:
-            return confidence < 0.2
-        return True
+    def _push_score(self, s: float) -> None:
+        self.window_scores.append(float(s))
+        if len(self.window_scores) > self.window_size:
+            self.window_scores = self.window_scores[-self.window_size :]
+
+    def _sustained_at_or_above(self, threshold: float) -> bool:
+        if len(self.window_scores) < self.min_sustain:
+            return False
+        return all(x >= threshold for x in self.window_scores[-self.min_sustain :])
+
+    def _sustained_below(self, threshold: float) -> bool:
+        if len(self.window_scores) < self.min_sustain:
+            return False
+        return all(x < threshold for x in self.window_scores[-self.min_sustain :])

--- a/src/plugins/cortex_adapter_plugin.py
+++ b/src/plugins/cortex_adapter_plugin.py
@@ -7,12 +7,21 @@ from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Protocol
 import json
 from datetime import datetime, timezone
+import time
+import uuid
 
 from src.core.plugin_interface import PluginInterface
 from src.core.event_bus import EventBus
 from src.core.events import create_event
 from src.core.temporal_graph import TemporalGraph, NeuralAtom
 from src.core.navigation import NeuralNavigator, NavigationStrategy
+from src.core.utils import (
+    normalize_text,
+    blake2b_hexdigest,
+    sha256_json,
+    redact_prompt_and_context,
+    CircuitBreaker,
+)
 
 
 class ExternalCortex(Protocol):
@@ -40,38 +49,55 @@ class CortexResponse:
 
 
 class GitHubCopilotCortex:
-    """Integration with GitHub Copilot via API."""
+    """Deterministic stub; replace with a real provider later."""
 
     async def reason(self, prompt: str, context: Dict[str, Any]) -> Dict[str, Any]:
         return {
-            "reasoning_steps": ["Analyzed prompt."],
-            "suggested_atoms": [
-                {"content": "Rate limiter implementation", "type": "code", "metadata": {}}
+            "reasoning_steps": [
+                "Analyze the problem context",
+                "Identify key concepts and relationships",
+                "Suggest solution approach",
             ],
-            "bonds_to_create": [],
+            "suggested_atoms": [
+                {
+                    "content": f"Solution approach for: {prompt[:50]}",
+                    "atom_type": "reasoning",
+                    "metadata": {
+                        "source": "github_copilot",
+                        "timestamp": datetime.now(timezone.utc).isoformat(),
+                    },
+                }
+            ],
+            "bonds_to_create": [
+                {
+                    "source_content": prompt[:30],
+                    "target_content": f"Solution approach for: {prompt[:50]}",
+                    "bond_type": "derives_solution",
+                    "reason": "cortex_reasoning",
+                    "context": context,
+                }
+            ],
             "confidence": 0.85,
         }
-
-    async def analyze_problem(self, problem: str) -> List[Dict[str, Any]]:
-        return []
-
-    async def suggest_tools(self, intent: str) -> List[str]:
-        return []
 
 
 class CortexAdapterPlugin(PluginInterface):
     """Plugin that adapts external AI systems as cognitive scaffolding."""
 
-    def __init__(
-        self, event_bus: EventBus, graph: TemporalGraph, navigator: NeuralNavigator
-    ) -> None:
+    def __init__(self, event_bus: EventBus, graph: TemporalGraph, navigator: NeuralNavigator) -> None:
         self.event_bus = event_bus
         self.graph = graph
         self.navigator = navigator
         self.cortex_providers: Dict[str, ExternalCortex] = {}
         self.learning_history: List[Dict[str, Any]] = []
+        # Hardening
+        self._dedup_index: Dict[str, str] = {}
+        self._quarantine_ttl_seconds = 7 * 24 * 3600
+        self._circuit = CircuitBreaker(failure_threshold=5, recovery_timeout=30.0)
+        self._budget_window_start = time.time()
+        self._budget_calls = 0
+        self._budget_max_per_min = 60
 
-        # Register event handlers
         self.event_bus.subscribe("reasoning_request", self.handle_reasoning_request)
         self.event_bus.subscribe("knowledge_gap", self.handle_knowledge_gap)
 
@@ -95,24 +121,56 @@ class CortexAdapterPlugin(PluginInterface):
         data = event.get("data", {}) if isinstance(event, dict) else {}
         prompt = data.get("prompt", "")
         context = dict(data.get("context", {}))
+        correlation_id = data.get("correlation_id") or str(uuid.uuid4())
+        trace_id = data.get("trace_id") or correlation_id
+
+        if not self._budget_allowed():
+            await self.event_bus.publish(
+                create_event(
+                    "cortex_budget_exceeded",
+                    event_version=1,
+                    source_plugin=self.name,
+                    correlation_id=correlation_id,
+                    trace_id=trace_id,
+                    reason="per-minute-limit",
+                )
+            )
+            return
+
+        if not self._circuit.allowed():
+            await self.event_bus.publish(
+                create_event(
+                    "cortex_circuit_open",
+                    event_version=1,
+                    source_plugin=self.name,
+                    correlation_id=correlation_id,
+                    trace_id=trace_id,
+                )
+            )
+            return
 
         current_knowledge = await self._build_context_from_graph(prompt)
         context.update(current_knowledge)
 
+        red_prompt, red_context, red_report = redact_prompt_and_context(prompt, context)
+        prompt_hash = sha256_json(red_prompt)
+        context_hash = sha256_json(red_context)
+
         for cortex_name, cortex in self.cortex_providers.items():
             try:
-                raw = await cortex.reason(prompt, context)
-                response = CortexResponse(
-                    reasoning_steps=raw.get("reasoning_steps", []),
-                    suggested_atoms=raw.get("suggested_atoms", []),
-                    bonds_to_create=raw.get("bonds_to_create", []),
-                    confidence=float(raw.get("confidence", 0.0)),
-                    metadata=raw.get("metadata"),
+                response_data = await cortex.reason(red_prompt, red_context)
+                response = CortexResponse(**response_data)
+                await self._learn_from_cortex_response(
+                    prompt=red_prompt,
+                    response=response,
+                    source=cortex_name,
+                    correlation_id=correlation_id,
+                    trace_id=trace_id,
+                    prompt_hash=prompt_hash,
+                    context_hash=context_hash,
                 )
+                self._circuit.on_success()
 
-                # Learn from the response
-                await self._learn_from_cortex_response(prompt, response, cortex_name)
-                # Emit learned knowledge
                 await self.event_bus.publish(
                     create_event(
                         "cortex_knowledge_learned",
@@ -123,9 +181,16 @@ class CortexAdapterPlugin(PluginInterface):
                         atoms_created=len(response.suggested_atoms),
                         bonds_created=len(response.bonds_to_create),
                         confidence=response.confidence,
+                        correlation_id=correlation_id,
+                        trace_id=trace_id,
+                        prompt_hash=prompt_hash,
+                        context_hash=context_hash,
+                        redaction_summary=red_report,
                     )
                 )
+                break
             except Exception as e:  # pragma: no cover - defensive
+                self._circuit.on_failure()
                 await self.event_bus.publish(
                     create_event(
                         "cortex_error",
@@ -134,6 +199,8 @@ class CortexAdapterPlugin(PluginInterface):
                         cortex_name=cortex_name,
                         error=str(e),
                         prompt=prompt,
+                        correlation_id=correlation_id,
+                        trace_id=trace_id,
                     )
                 )
 
@@ -142,8 +209,7 @@ class CortexAdapterPlugin(PluginInterface):
         data = event.get("data", {}) if isinstance(event, dict) else {}
         gap_description = data.get("gap_description", "unspecified gap")
         context = dict(data.get("context", {}))
-
-        gap_prompt = f"Help resolve knowledge gap: {gap_description}"
+        gap_prompt = f"Fill knowledge gap: {gap_description}"
         await self.event_bus.publish(
             create_event(
                 "reasoning_request",
@@ -156,78 +222,122 @@ class CortexAdapterPlugin(PluginInterface):
         )
 
     async def _build_context_from_graph(self, prompt: str) -> Dict[str, Any]:
-        """Build context from current graph state."""
+        """Build context from current graph via semantic navigation."""
         relevant_atoms = await self.navigator.navigate(
             prompt,
             NavigationStrategy.SEMANTIC,
             depth=5,
             semantic_query=prompt,
         )
-
         return {
             "relevant_knowledge": [
-                {
-                    "content": atom.content,
-                    "type": atom.atom_type,
-                    "uuid": atom.uuid,
-                }
-                for atom in relevant_atoms[:10]
+                {"content": a.content, "type": a.atom_type, "uuid": a.uuid}
+                for a in relevant_atoms[:10]
             ],
             "graph_stats": {
                 "total_atoms": len(self.graph.atoms),
-                "connection_count": sum(
-                    len(a.bonds_out()) for a in self.graph.atoms.values()
-                ),
+                "connection_count": sum(len(a.bonds_out()) for a in self.graph.atoms.values()),
             },
         }
 
-    def _find_or_create_atom(self, content: str) -> Optional[NeuralAtom]:
-        """Find existing atom or create new one."""
-        content_lower = content.lower()
-        for atom in self.graph.atoms.values():
-            if content_lower in atom.content.lower():
-                return atom
-        return self.graph.create_atom(content, "concept", {})
-
     async def _learn_from_cortex_response(
-        self, prompt: str, response: CortexResponse, cortex_name: str
+        self,
+        prompt: str,
+        response: CortexResponse,
+        source: str,
+        *,
+        correlation_id: str,
+        trace_id: str,
+        prompt_hash: str,
+        context_hash: str,
     ) -> None:
-        for atom_info in response.suggested_atoms:
-            content = atom_info.get("content", "")
-            atom_type = atom_info.get("type", "concept")
-            metadata = atom_info.get("metadata", {})
-            self._find_or_create_atom(content) or self.graph.create_atom(
-                content, atom_type, metadata
+        created_atoms: List[NeuralAtom] = []
+        for atom_data in response.suggested_atoms:
+            meta = {
+                **atom_data.get("metadata", {}),
+                "cortex_source": source,
+                "learned_from": prompt,
+                "confidence": response.confidence,
+                "status": "quarantined",
+                "provenance": {
+                    "correlation_id": correlation_id,
+                    "trace_id": trace_id,
+                    "prompt_hash": prompt_hash,
+                    "context_hash": context_hash,
+                    "provider": source,
+                },
+            }
+            atom = await self._create_or_get_atom(
+                content=atom_data["content"],
+                atom_type=atom_data.get("atom_type", "learned"),
+                metadata=meta,
             )
-        for bond in response.bonds_to_create:
-            src = bond.get("source")
-            tgt = bond.get("target")
+            created_atoms.append(atom)
+        for bond_data in response.bonds_to_create:
+            src = self._find_or_create_atom(bond_data["source_content"])
+            tgt = self._find_or_create_atom(bond_data["target_content"])
             if src and tgt:
-                self.graph.create_bond(src, tgt, bond.get("metadata", {}))
-
+                self.graph.create_bond(
+                    src.uuid,
+                    tgt.uuid,
+                    {
+                        **bond_data.get("context", {}),
+                        "bond_type": bond_data.get("bond_type", "learned_relation"),
+                        "reason": bond_data.get("reason", f"cortex_{source}"),
+                        "cortex_source": source,
+                        "confidence": response.confidence,
+                        "status": "quarantined",
+                        "provenance": {
+                            "correlation_id": correlation_id,
+                            "trace_id": trace_id,
+                            "prompt_hash": prompt_hash,
+                            "context_hash": context_hash,
+                            "provider": source,
+                        },
+                    },
+                )
         self.learning_history.append(
             {
                 "timestamp": datetime.now(timezone.utc).isoformat(),
                 "prompt": prompt,
-                "cortex": cortex_name,
+                "cortex_source": source,
+                "atoms_created": len(created_atoms),
                 "confidence": response.confidence,
+                "reasoning_steps": response.reasoning_steps,
             }
         )
 
-    async def get_learning_stats(self) -> Dict[str, Any]:
-        """Get statistics about cortex-assisted learning."""
-        if not self.learning_history:
-            return {"total_sessions": 0}
+    async def _create_or_get_atom(self, content: str, atom_type: str, metadata: Dict[str, Any]) -> NeuralAtom:
+        key_norm = normalize_text(content or "")
+        key = blake2b_hexdigest(f"{atom_type}|{key_norm}")
+        existing_uuid = self._dedup_index.get(key)
+        if existing_uuid:
+            return self.graph.atoms[existing_uuid]
+        atom = self.graph.create_atom(content=content, atom_type=atom_type, metadata=metadata)
+        self._dedup_index[key] = atom.uuid
+        return atom
 
-        total_sessions = len(self.learning_history)
-        avg_confidence = sum(
-            s["confidence"] for s in self.learning_history
-        ) / total_sessions
-        cortex_sources = {s["cortex"] for s in self.learning_history}
+    def _find_or_create_atom(self, content: str) -> Optional[NeuralAtom]:
+        needle = (content or "").lower()
+        for atom in self.graph.atoms.values():
+            if needle and needle in (atom.content or "").lower():
+                return atom
+        return self.graph.create_atom(
+            content=content,
+            atom_type="auto_created",
+            metadata={"source": "cortex_adapter"},
+        )
 
-        return {
-            "total_sessions": total_sessions,
-            "average_confidence": avg_confidence,
-            "cortex_sources": list(cortex_sources),
-            "recent_sessions": self.learning_history[-5:],
-        }
+    def _budget_allowed(self) -> bool:
+        now = time.time()
+        if (now - self._budget_window_start) >= 60.0:
+            self._budget_window_start = now
+            self._budget_calls = 0
+        self._budget_calls += 1
+        return self._budget_calls <= self._budget_max_per_min
+
+    def maintenance_tick(self, now: Optional[float] = None) -> int:
+        now = now or time.time()
+        removed = 0
+        # Placeholder for future quarantine GC
+        return removed

--- a/src/plugins/knowledge_gap_detector.py
+++ b/src/plugins/knowledge_gap_detector.py
@@ -2,20 +2,30 @@
 Detects when the agent encounters knowledge gaps and needs cortex assistance.
 """
 from __future__ import annotations
-from typing import Dict, Any, List
+
+from typing import Any, Dict, List, Protocol
+import uuid
 
 from src.core.plugin_interface import PluginInterface
 from src.core.event_bus import EventBus
 from src.core.events import create_event
+from src.core.utils import CooldownLRU
+
+
+class CortexPolicy(Protocol):
+    async def should_use_cortex(self, confidence: float, context: Dict[str, Any]) -> bool:
+        ...
 
 
 class KnowledgeGapDetector(PluginInterface):
     """Detects when agent needs external assistance."""
 
-    def __init__(self, event_bus: EventBus):
+    def __init__(self, event_bus: EventBus, policy: CortexPolicy | None = None, *, cooldown_seconds: float = 300.0):
         self.event_bus = event_bus
-        self.confidence_threshold = 0.3  # Below this, seek help
-        # Normalize patterns to lowercase; we'll lowercase incoming content
+        self.policy = policy
+        self.confidence_threshold = 0.3
+        self.max_hops = 3
+        self.cooldown = CooldownLRU(ttl_seconds=cooldown_seconds)
         self.gap_patterns = [
             "i don't know",
             "i'm not sure",
@@ -23,6 +33,9 @@ class KnowledgeGapDetector(PluginInterface):
             "need more data",
             "unclear how to proceed",
         ]
+        self.event_bus.subscribe("reasoning_complete", self.check_reasoning_confidence)
+        self.event_bus.subscribe("navigation_complete", self.check_navigation_success)
+        self.event_bus.subscribe("conversation_turn", self.detect_uncertainty_patterns)
 
     @property
     def name(self) -> str:  # type: ignore[override]
@@ -36,55 +49,61 @@ class KnowledgeGapDetector(PluginInterface):
     async def start(self) -> None:  # type: ignore[override]
         self.is_running = True
 
-    async def check_reasoning_confidence(self, event: Dict[str, Any]):
-        """Check if reasoning confidence is too low."""
+    async def check_reasoning_confidence(self, event: Dict[str, Any]) -> None:
         data = event.get("data", {}) if isinstance(event, dict) else {}
         confidence = float(data.get("confidence", 1.0))
-
         if confidence < self.confidence_threshold:
-            await self.event_bus.publish(
-                create_event(
-                    "knowledge_gap",
-                    event_version=1,
-                    source_plugin=self.name,
-                    gap_description=f"Low confidence reasoning: {confidence}",
-                    context=data,
-                    gap_type="low_confidence",
-                )
+            await self._maybe_publish_gap(
+                gap_description=f"Low confidence reasoning: {confidence:.2f}",
+                context=data,
+                gap_type="low_confidence",
             )
 
-    async def check_navigation_success(self, event: Dict[str, Any]):
-        """Check if navigation found useful paths."""
+    async def check_navigation_success(self, event: Dict[str, Any]) -> None:
         data = event.get("data", {}) if isinstance(event, dict) else {}
         path_length = int(data.get("path_length", 0))
-
-        if path_length <= 1:  # Only found starting atom
-            await self.event_bus.publish(
-                create_event(
-                    "knowledge_gap",
-                    event_version=1,
-                    source_plugin=self.name,
-                    gap_description="Navigation found no relevant connections",
-                    context=data,
-                    gap_type="isolated_knowledge",
-                )
+        if path_length <= 1:
+            await self._maybe_publish_gap(
+                gap_description="Navigation found no relevant connections",
+                context=data,
+                gap_type="isolated_knowledge",
             )
 
-    async def detect_uncertainty_patterns(self, event: Dict[str, Any]):
-        """Detect uncertainty patterns in conversation."""
+    async def detect_uncertainty_patterns(self, event: Dict[str, Any]) -> None:
         data = event.get("data", {}) if isinstance(event, dict) else {}
         content = str(data.get("content", "")).lower()
-
         for pattern in self.gap_patterns:
             if pattern in content:
-                await self.event_bus.publish(
-                    create_event(
-                        "knowledge_gap",
-                        event_version=1,
-                        source_plugin=self.name,
-                        gap_description=f"Uncertainty pattern detected: {pattern}",
-                        context=data,
-                        gap_type="uncertainty_expression",
-                    )
+                await self._maybe_publish_gap(
+                    gap_description=f"Uncertainty pattern detected: {pattern}",
+                    context=data,
+                    gap_type="uncertainty_expression",
                 )
                 break
+
+    async def _maybe_publish_gap(self, *, gap_description: str, context: Dict[str, Any], gap_type: str) -> None:
+        topic = context.get("topic_id") or context.get("prompt_hash") or context.get("goal") or gap_type
+        if self.cooldown.hit(str(topic)):
+            return
+        hop_count = int(context.get("hop_count", 0))
+        if hop_count >= self.max_hops:
+            return
+        if self.policy is not None:
+            ok = await self.policy.should_use_cortex(
+                confidence=float(context.get("confidence", 0.0)),
+                context=context,
+            )
+            if not ok:
+                return
+        correlation_id = context.get("correlation_id") or str(uuid.uuid4())
+        trace_id = context.get("trace_id") or correlation_id
+        await self.event_bus.publish(
+            create_event(
+                "knowledge_gap",
+                event_version=1,
+                source_plugin=self.name,
+                gap_description=gap_description,
+                context={**context, "hop_count": hop_count + 1, "correlation_id": correlation_id, "trace_id": trace_id},
+                gap_type=gap_type,
+            )
+        )

--- a/tests/core_utils/test_utils_core.py
+++ b/tests/core_utils/test_utils_core.py
@@ -1,0 +1,51 @@
+import time
+from src.core.utils import (
+    normalize_text,
+    blake2b_hexdigest,
+    sha256_json,
+    redact_prompt_and_context,
+    CircuitBreaker,
+    CooldownLRU,
+)
+
+
+def test_normalize_and_hash():
+    n = normalize_text(" Hello,  WORLD!! ")
+    assert n == "hello world"
+    h1 = blake2b_hexdigest(n)
+    h2 = blake2b_hexdigest("hello world")
+    assert h1 == h2
+    sj = sha256_json({"b": 1, "a": 2})
+    sj2 = sha256_json({"a": 2, "b": 1})
+    assert sj == sj2
+
+
+def test_redaction_masks_sensitive():
+    p = "contact me at user@example.com; api_key=SECRET123SECRET123"
+    red_p, red_c, report = redact_prompt_and_context(p, {"token": "abcd" * 10})
+    assert "@" not in red_p
+    assert "api_key" in red_p
+    assert "…" in red_p
+    assert "…" in str(red_c)
+    assert "prompt_redactions" in report
+
+
+def test_circuit_breaker_opens_and_recovers():
+    cb = CircuitBreaker(failure_threshold=2, recovery_timeout=0.2)
+    assert cb.allowed() is True
+    cb.on_failure()
+    assert cb.allowed() is True
+    cb.on_failure()
+    assert cb.allowed() is False
+    time.sleep(0.25)
+    assert cb.allowed() is True
+    cb.on_success()
+    assert cb.allowed() is True
+
+
+def test_cooldown_lru():
+    cd = CooldownLRU(ttl_seconds=0.1)
+    assert cd.hit("k") is False
+    assert cd.hit("k") is True
+    time.sleep(0.15)
+    assert cd.hit("k") is False

--- a/tests/integration/test_cortex_integration.py
+++ b/tests/integration/test_cortex_integration.py
@@ -1,0 +1,51 @@
+import pytest
+from unittest.mock import AsyncMock
+
+from src.core.event_bus import EventBus
+from src.core.temporal_graph import TemporalGraph
+from src.core.navigation import NeuralNavigator, NavigationConfig
+from src.integration.cortex_integration import CortexIntegration
+
+
+@pytest.mark.asyncio
+async def test_integration_phase_advance_event():
+    bus = AsyncMock(spec=EventBus)
+    g = TemporalGraph()
+    nav = NeuralNavigator(graph=g, config=NavigationConfig(enable_telemetry=False))
+    integ = CortexIntegration(event_bus=bus, graph=g, navigator=nav)
+
+    await integ.handle_autonomy_update({"data": {"current_score": 0.9}})
+    await integ.handle_autonomy_update({"data": {"current_score": 0.9}})
+    await integ.handle_autonomy_update({"data": {"current_score": 0.9}})
+    assert bus.publish.called
+    payloads = [c.args[0] for c in bus.publish.call_args_list]
+    types = [getattr(p, "event_type", getattr(p, "type", None)) for p in payloads]
+    assert "phase_advanced" in types
+
+
+@pytest.mark.asyncio
+async def test_should_use_cortex_policy():
+    bus = AsyncMock(spec=EventBus)
+    g = TemporalGraph()
+    nav = NeuralNavigator(graph=g, config=NavigationConfig(enable_telemetry=False))
+    integ = CortexIntegration(event_bus=bus, graph=g, navigator=nav)
+    assert await integ.should_use_cortex(0.2) is True
+    assert await integ.should_use_cortex(0.95) is False
+
+
+@pytest.mark.asyncio
+async def test_phase_demotion_event():
+    bus = AsyncMock(spec=EventBus)
+    g = TemporalGraph()
+    nav = NeuralNavigator(graph=g, config=NavigationConfig(enable_telemetry=False))
+    integ = CortexIntegration(event_bus=bus, graph=g, navigator=nav)
+    await integ.handle_autonomy_update({"data": {"current_score": 0.35}})
+    await integ.handle_autonomy_update({"data": {"current_score": 0.36}})
+    await integ.handle_autonomy_update({"data": {"current_score": 0.37}})
+    await integ.handle_autonomy_update({"data": {"current_score": 0.2}})
+    await integ.handle_autonomy_update({"data": {"current_score": 0.2}})
+    await integ.handle_autonomy_update({"data": {"current_score": 0.2}})
+    assert bus.publish.called
+    payloads = [c.args[0] for c in bus.publish.call_args_list]
+    types = [getattr(p, "event_type", getattr(p, "type", None)) for p in payloads]
+    assert "phase_demoted" in types

--- a/tests/orchestration/test_cortex_weaning.py
+++ b/tests/orchestration/test_cortex_weaning.py
@@ -1,0 +1,47 @@
+import pytest
+from src.orchestration.cortex_weaning import CortexWeaningOrchestrator, TrainingPhase
+
+import pytest
+from src.orchestration.cortex_weaning import CortexWeaningOrchestrator, TrainingPhase
+
+
+@pytest.mark.asyncio
+async def test_should_use_cortex_thresholds_and_phase_lift():
+    o = CortexWeaningOrchestrator()
+    assert await o.should_use_cortex(0.2, {}) is True
+    assert await o.should_use_cortex(0.9, {}) is False
+    assert await o.advance_phase_if_ready(0.36) is False
+    assert await o.advance_phase_if_ready(0.37) is False
+    assert await o.advance_phase_if_ready(0.38) is True
+    assert o.current_phase == TrainingPhase.GUIDED
+
+
+@pytest.mark.asyncio
+async def test_phase_advance_multiple():
+    o = CortexWeaningOrchestrator()
+    await o.advance_phase_if_ready(0.35)
+    await o.advance_phase_if_ready(0.36)
+    await o.advance_phase_if_ready(0.37)
+    await o.advance_phase_if_ready(0.56)
+    await o.advance_phase_if_ready(0.57)
+    await o.advance_phase_if_ready(0.58)
+    assert o.current_phase == TrainingPhase.SUPERVISED
+
+
+@pytest.mark.asyncio
+async def test_phase_demotion_on_sustained_drop():
+    o = CortexWeaningOrchestrator()
+    await o.advance_phase_if_ready(0.35)
+    await o.advance_phase_if_ready(0.36)
+    await o.advance_phase_if_ready(0.37)
+    await o.advance_phase_if_ready(0.56)
+    await o.advance_phase_if_ready(0.57)
+    await o.advance_phase_if_ready(0.58)
+    assert o.current_phase == TrainingPhase.SUPERVISED
+    o.window_scores.clear()
+    o._push_score(0.40)
+    o._push_score(0.40)
+    o._push_score(0.40)
+    demoted = await o.maybe_demote_phase()
+    assert demoted is True
+    assert o.current_phase == TrainingPhase.GUIDED

--- a/tests/plugins/test_cortex_adapter.py
+++ b/tests/plugins/test_cortex_adapter.py
@@ -1,0 +1,68 @@
+import pytest
+import time
+from unittest.mock import AsyncMock
+
+from src.core.event_bus import EventBus
+from src.core.temporal_graph import TemporalGraph
+from src.core.navigation import NeuralNavigator, NavigationConfig
+from src.plugins.cortex_adapter_plugin import CortexAdapterPlugin, GitHubCopilotCortex
+
+
+@pytest.mark.asyncio
+async def test_cortex_adapter_learning_flow():
+    bus = AsyncMock(spec=EventBus)
+    g = TemporalGraph()
+    g.create_atom("rate limiter", "topic", {})
+    nav = NeuralNavigator(graph=g, config=NavigationConfig(enable_telemetry=False))
+
+    adapter = CortexAdapterPlugin(event_bus=bus, graph=g, navigator=nav)
+    adapter.register_cortex("github_copilot", GitHubCopilotCortex())
+
+    await adapter.handle_reasoning_request({"data": {"prompt": "Implement a rate limiter", "context": {"user": "t"}}})
+    assert bus.publish.called
+    payloads = [c.args[0] for c in bus.publish.call_args_list]
+    assert any(getattr(p, "event_type", getattr(p, "type", None)) == "cortex_knowledge_learned" for p in payloads)
+    assert len(g.atoms) >= 2
+    learned = [p for p in payloads if getattr(p, "event_type", getattr(p, "type", None)) == "cortex_knowledge_learned"][0]
+    assert hasattr(learned, "redaction_summary")
+
+
+@pytest.mark.asyncio
+async def test_gap_event_triggers_reasoning_request():
+    bus = AsyncMock(spec=EventBus)
+    g = TemporalGraph()
+    nav = NeuralNavigator(graph=g, config=NavigationConfig(enable_telemetry=False))
+    adapter = CortexAdapterPlugin(event_bus=bus, graph=g, navigator=nav)
+    adapter.register_cortex("github_copilot", GitHubCopilotCortex())
+
+    await adapter.handle_knowledge_gap({"data": {"gap_description": "missing rate limiter concept"}})
+    assert bus.publish.called
+    payload = bus.publish.call_args.args[0]
+    assert getattr(payload, "event_type", getattr(payload, "type", None)) == "reasoning_request"
+
+
+@pytest.mark.asyncio
+async def test_budget_and_circuit_breaker_paths():
+    bus = AsyncMock(spec=EventBus)
+    g = TemporalGraph()
+    nav = NeuralNavigator(graph=g, config=NavigationConfig(enable_telemetry=False))
+    adapter = CortexAdapterPlugin(event_bus=bus, graph=g, navigator=nav)
+    adapter._budget_max_per_min = 1
+    adapter._circuit.failure_threshold = 1
+    await adapter.handle_reasoning_request({"data": {"prompt": "A"}})
+    await adapter.handle_reasoning_request({"data": {"prompt": "B"}})
+    payloads = [c.args[0] for c in bus.publish.call_args_list]
+    assert any(getattr(p, "event_type", getattr(p, "type", None)) == "cortex_budget_exceeded" for p in payloads)
+
+    class BadCortex:
+        async def reason(self, p, c):
+            raise RuntimeError("boom")
+
+    adapter.cortex_providers = {"bad": BadCortex()}
+    adapter._budget_window_start = time.time()
+    adapter._budget_calls = 0
+    adapter._budget_max_per_min = 100
+    await adapter.handle_reasoning_request({"data": {"prompt": "C"}})
+    await adapter.handle_reasoning_request({"data": {"prompt": "C"}})
+    payloads2 = [c.args[0] for c in bus.publish.call_args_list]
+    assert any(getattr(p, "event_type", getattr(p, "type", None)) == "cortex_circuit_open" for p in payloads2)

--- a/tests/plugins/test_knowledge_gap_detector.py
+++ b/tests/plugins/test_knowledge_gap_detector.py
@@ -1,0 +1,50 @@
+import pytest
+from unittest.mock import AsyncMock
+from src.core.event_bus import EventBus
+from src.plugins.knowledge_gap_detector import KnowledgeGapDetector
+
+
+@pytest.mark.asyncio
+async def test_gap_on_low_confidence():
+    bus = AsyncMock(spec=EventBus)
+    class AllowAll:
+        async def should_use_cortex(self, confidence, context):
+            return True
+    det = KnowledgeGapDetector(event_bus=bus, policy=AllowAll())
+    await det.check_reasoning_confidence({"data": {"confidence": 0.1}})
+    assert bus.publish.called
+    payload = bus.publish.call_args.args[0]
+    assert getattr(payload, "event_type", getattr(payload, "type", None)) == "knowledge_gap"
+    assert getattr(payload, "gap_type", None) == "low_confidence"
+
+
+@pytest.mark.asyncio
+async def test_gap_on_short_path():
+    bus = AsyncMock(spec=EventBus)
+    class AllowAll:
+        async def should_use_cortex(self, confidence, context):
+            return True
+    det = KnowledgeGapDetector(event_bus=bus, policy=AllowAll())
+    await det.check_navigation_success({"data": {"path_length": 1}})
+    assert bus.publish.called
+    payload = bus.publish.call_args.args[0]
+    assert getattr(payload, "event_type", getattr(payload, "type", None)) == "knowledge_gap"
+    assert getattr(payload, "gap_type", None) == "isolated_knowledge"
+
+
+@pytest.mark.asyncio
+async def test_gap_on_uncertainty_pattern():
+    bus = AsyncMock(spec=EventBus)
+    class AllowAll:
+        async def should_use_cortex(self, confidence, context):
+            return True
+    det = KnowledgeGapDetector(event_bus=bus, policy=AllowAll(), cooldown_seconds=0.5)
+    await det.detect_uncertainty_patterns({"data": {"content": "I'm not sure about this"}})
+    assert bus.publish.called
+    payload = bus.publish.call_args.args[0]
+    assert getattr(payload, "event_type", getattr(payload, "type", None)) == "knowledge_gap"
+    assert getattr(payload, "gap_type", None) == "uncertainty_expression"
+    await det.detect_uncertainty_patterns({"data": {"content": "I'm not sure again"}})
+    assert bus.publish.call_count == 1
+    await det._maybe_publish_gap(gap_description="x", context={"hop_count": 3}, gap_type="t")
+    assert bus.publish.call_count == 1


### PR DESCRIPTION
## Summary
- add redaction, hashing, cooldown, and circuit breaker utilities
- harden cortex adapter with dedup, budget and provenance tracking
- gate knowledge-gap requests through weaning policy and add phase demotion

## Testing
- `pre-commit run --all-files`
- `pytest -q tests/core_utils/test_utils_core.py tests/plugins/test_cortex_adapter.py tests/plugins/test_knowledge_gap_detector.py tests/orchestration/test_cortex_weaning.py tests/integration/test_cortex_integration.py`
- `pytest -q tests/runtime`


------
https://chatgpt.com/codex/tasks/task_e_68aa4e4ca8548328b9911e5680af691e