### PR TITLE
[puter] add Puter plugin integration

### DIFF
--- a/config/puter_config.py
+++ b/config/puter_config.py
@@ -1,0 +1,21 @@
+"""
+Configuration for Puter plugin integration.
+"""
+
+import os
+
+PUTER_CONFIG = {
+    "base_url": "https://puter.com",
+    "api_key": None,
+    "timeout": 30,
+    "max_retries": 3,
+    "auto_create_dirs": True,
+    "default_working_directory": "/",
+    "log_level": "INFO",
+}
+
+if os.getenv("PUTER_API_KEY"):
+    PUTER_CONFIG["api_key"] = os.getenv("PUTER_API_KEY")
+
+if os.getenv("PUTER_BASE_URL"):
+    PUTER_CONFIG["base_url"] = os.getenv("PUTER_BASE_URL")

--- a/examples/puter_integration_example.py
+++ b/examples/puter_integration_example.py
@@ -1,0 +1,33 @@
+"""
+Example of using Puter integration with agent framework.
+"""
+
+import asyncio
+import logging
+
+from config.puter_config import PUTER_CONFIG
+from src.puter.plugin_registry import PluginRegistry
+from src.puter.tools_registry import ToolsRegistry
+
+
+async def main() -> None:
+    logging.basicConfig(level=logging.INFO)
+    registry = PluginRegistry()
+    await registry.initialize_plugin("puter", PUTER_CONFIG)
+    tools_registry = ToolsRegistry(registry)
+    await tools_registry.initialize_tools()
+    puter_tool = tools_registry.get_tool("puter")
+    if puter_tool:
+        print("Current directory:", puter_tool.get_current_directory())
+        files = await puter_tool.list_directory()
+        print("Files:", [f["name"] for f in files])
+        await puter_tool.write_file("test_file.txt", "Hello from agent!")
+        content = await puter_tool.read_file("test_file.txt")
+        print("File content:", content)
+        result = await puter_tool.execute_command("ls", ["-la"])
+        print("Command output:", result["stdout"])
+    await registry.cleanup_all()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/puter/plugin_interface.py
+++ b/src/puter/plugin_interface.py
@@ -1,0 +1,27 @@
+"""
+Base interface for agent plugins.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict
+
+
+class PluginInterface(ABC):
+    """Base interface that all plugins must implement."""
+
+    def __init__(self, config: Dict[str, Any]):
+        """Initialize plugin with configuration."""
+        self.config = config
+        self.is_initialized = False
+
+    @abstractmethod
+    async def initialize(self) -> None:
+        """Initialize the plugin."""
+
+    @abstractmethod
+    async def cleanup(self) -> None:
+        """Clean up plugin resources."""
+
+    @abstractmethod
+    def get_plugin_info(self) -> Dict[str, Any]:
+        """Get plugin information."""

--- a/src/puter/plugin_registry.py
+++ b/src/puter/plugin_registry.py
@@ -1,0 +1,51 @@
+"""
+Plugin registry for managing agent plugins.
+"""
+
+import logging
+from typing import Any, Dict, Optional, Type
+
+from .plugin_interface import PluginInterface
+from .puter_plugin import PuterPlugin
+
+logger = logging.getLogger(__name__)
+
+
+class PluginRegistry:
+    """Registry for managing and initializing plugins."""
+
+    def __init__(self) -> None:
+        self.plugins: Dict[str, PluginInterface] = {}
+        self.plugin_classes: Dict[str, Type[PluginInterface]] = {
+            "puter": PuterPlugin,
+        }
+
+    async def initialize_plugin(self, plugin_name: str, config: Dict[str, Any]) -> None:
+        if plugin_name in self.plugins:
+            logger.warning("Plugin %s already initialized", plugin_name)
+            return
+        if plugin_name not in self.plugin_classes:
+            raise ValueError(f"Unknown plugin: {plugin_name}")
+        plugin_class = self.plugin_classes[plugin_name]
+        plugin = plugin_class(config)
+        await plugin.initialize()
+        self.plugins[plugin_name] = plugin
+        logger.info("Successfully initialized plugin: %s", plugin_name)
+
+    def get_plugin(self, plugin_name: str) -> Optional[PluginInterface]:
+        return self.plugins.get(plugin_name)
+
+    async def cleanup_all(self) -> None:
+        for name, plugin in list(self.plugins.items()):
+            try:
+                await plugin.cleanup()
+                logger.info("Cleaned up plugin: %s", name)
+            except Exception as exc:  # pragma: no cover - cleanup error
+                logger.error("Error cleaning up plugin %s: %s", name, exc)
+        self.plugins.clear()
+
+    def list_available_plugins(self) -> list[str]:
+        return list(self.plugin_classes.keys())
+
+    def list_initialized_plugins(self) -> list[str]:
+        return list(self.plugins.keys())

--- a/src/puter/puter_plugin.py
+++ b/src/puter/puter_plugin.py
@@ -1,0 +1,184 @@
+"""
+Puter Plugin for Agent Framework Integration
+
+This plugin provides seamless integration with Puter's cloud environment,
+enabling file I/O operations and process execution through Puter's API.
+"""
+
+import asyncio
+import logging
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+from urllib.parse import urljoin
+
+import aiohttp
+
+from .plugin_interface import PluginInterface
+
+logger = logging.getLogger(__name__)
+
+
+class PuterAPIError(Exception):
+    """Custom exception for Puter API errors"""
+
+
+class PuterPlugin(PluginInterface):
+    """Plugin for integrating with Puter cloud environment."""
+
+    def __init__(self, config: Dict[str, Any]):
+        super().__init__(config)
+        self.base_url = config.get("base_url", "https://puter.com")
+        self.api_key = config.get("api_key")
+        self.timeout = config.get("timeout", 30)
+        self.max_retries = config.get("max_retries", 3)
+        self.session: Optional[aiohttp.ClientSession] = None
+        self.current_directory = "/"
+
+    async def initialize(self) -> None:
+        """Initialize the plugin and establish connection to Puter."""
+        connector = aiohttp.TCPConnector(limit=100, limit_per_host=30)
+        timeout = aiohttp.ClientTimeout(total=self.timeout)
+        headers = {"User-Agent": "PuterAgent/1.0", "Content-Type": "application/json"}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+
+        self.session = aiohttp.ClientSession(
+            connector=connector, timeout=timeout, headers=headers
+        )
+
+        try:
+            await self._make_request("GET", "/api/health")
+            logger.info("Successfully connected to Puter instance")
+            self.is_initialized = True
+        except Exception as exc:  # pragma: no cover - network failure
+            logger.error("Failed to connect to Puter: %s", exc)
+            raise PuterAPIError(f"Connection failed: {exc}")
+
+    async def cleanup(self) -> None:
+        if self.session:
+            await self.session.close()
+            self.session = None
+            self.is_initialized = False
+
+    async def _make_request(
+        self,
+        method: str,
+        endpoint: str,
+        data: Optional[Dict[str, Any]] = None,
+        params: Optional[Dict[str, Any]] = None,
+        retry_count: int = 0,
+    ) -> Dict[str, Any]:
+        if not self.session:
+            raise PuterAPIError("Plugin not initialized")
+
+        url = urljoin(self.base_url, endpoint)
+        try:
+            async with self.session.request(
+                method, url, json=data, params=params
+            ) as response:
+                response_data = await response.json()
+                if response.status >= 400:
+                    error_msg = response_data.get("error", f"HTTP {response.status}")
+                    raise PuterAPIError(f"API Error: {error_msg}")
+                return response_data
+        except aiohttp.ClientError as exc:
+            if retry_count < self.max_retries:
+                await asyncio.sleep(2 ** retry_count)
+                return await self._make_request(
+                    method, endpoint, data, params, retry_count + 1
+                )
+            raise PuterAPIError(f"Network error: {exc}")
+
+    def _resolve_path(self, path: str) -> str:
+        if path.startswith("/"):
+            return path
+        if path == ".":
+            return self.current_directory
+        if path == "..":
+            return str(Path(self.current_directory).parent)
+        return str(Path(self.current_directory) / path)
+
+    # File I/O operations
+    async def read_file(self, path: str) -> str:
+        full_path = self._resolve_path(path)
+        response = await self._make_request(
+            "GET", "/api/fs/read", params={"path": full_path}
+        )
+        return response.get("content", "")
+
+    async def write_file(self, path: str, content: str, create_dirs: bool = True) -> bool:
+        full_path = self._resolve_path(path)
+        data = {"path": full_path, "content": content, "create_dirs": create_dirs}
+        await self._make_request("POST", "/api/fs/write", data=data)
+        return True
+
+    async def list_directory(self, path: str = ".") -> List[Dict[str, Any]]:
+        full_path = self._resolve_path(path)
+        response = await self._make_request(
+            "GET", "/api/fs/list", params={"path": full_path}
+        )
+        return response.get("items", [])
+
+    async def delete_file(self, path: str) -> bool:
+        full_path = self._resolve_path(path)
+        await self._make_request("DELETE", "/api/fs/delete", params={"path": full_path})
+        return True
+
+    async def create_directory(self, path: str) -> bool:
+        full_path = self._resolve_path(path)
+        await self._make_request("POST", "/api/fs/mkdir", data={"path": full_path})
+        return True
+
+    # Process execution
+    async def execute_command(
+        self,
+        command: str,
+        args: Optional[List[str]] = None,
+        cwd: Optional[str] = None,
+        env: Optional[Dict[str, str]] = None,
+    ) -> Dict[str, Any]:
+        working_dir = self._resolve_path(cwd) if cwd else self.current_directory
+        data = {
+            "command": command,
+            "args": args or [],
+            "cwd": working_dir,
+            "env": env or {},
+        }
+        response = await self._make_request("POST", "/api/exec", data=data)
+        return {
+            "stdout": response.get("stdout", ""),
+            "stderr": response.get("stderr", ""),
+            "exit_code": response.get("exit_code", 0),
+            "execution_time": response.get("execution_time", 0),
+        }
+
+    # Directory navigation
+    async def change_directory(self, path: str) -> str:
+        new_path = self._resolve_path(path)
+        try:
+            await self.list_directory(new_path)
+            self.current_directory = new_path
+            return self.current_directory
+        except PuterAPIError as exc:
+            raise PuterAPIError(f"Directory does not exist: {new_path}") from exc
+
+    def get_current_directory(self) -> str:
+        return self.current_directory
+
+    async def get_file_info(self, path: str) -> Dict[str, Any]:
+        full_path = self._resolve_path(path)
+        return await self._make_request(
+            "GET", "/api/fs/stat", params={"path": full_path}
+        )
+
+    def get_plugin_info(self) -> Dict[str, Any]:
+        return {
+            "name": "PuterPlugin",
+            "version": "1.0.0",
+            "description": "Integration with Puter cloud environment",
+            "capabilities": [
+                "file_io",
+                "process_execution",
+                "directory_management",
+            ],
+        }

--- a/src/puter/tools_registry.py
+++ b/src/puter/tools_registry.py
@@ -1,0 +1,156 @@
+"""
+Tools registry with Puter integration.
+"""
+
+import logging
+from typing import Any, Dict, List, Optional
+
+from .plugin_registry import PluginRegistry
+from .puter_plugin import PuterPlugin, PuterAPIError
+
+logger = logging.getLogger(__name__)
+
+
+class PuterTool:
+    """Tool for interacting with Puter cloud environment."""
+
+    def __init__(self, plugin_registry: PluginRegistry):
+        self.plugin_registry = plugin_registry
+        self.puter_plugin: Optional[PuterPlugin] = None
+
+    async def initialize(self) -> None:
+        self.puter_plugin = self.plugin_registry.get_plugin("puter")
+        if not self.puter_plugin:
+            raise RuntimeError("Puter plugin not initialized in registry")
+
+    async def execute_command(
+        self,
+        command: str,
+        args: Optional[List[str]] = None,
+        cwd: Optional[str] = None,
+        env: Optional[Dict[str, str]] = None,
+    ) -> Dict[str, Any]:
+        if not self.puter_plugin:
+            raise RuntimeError("PuterTool not initialized")
+        try:
+            result = await self.puter_plugin.execute_command(
+                command=command, args=args, cwd=cwd, env=env
+            )
+            await self._emit_event(
+                "command_executed",
+                {
+                    "command": command,
+                    "args": args,
+                    "exit_code": result["exit_code"],
+                    "execution_time": result["execution_time"],
+                },
+            )
+            return result
+        except PuterAPIError as exc:
+            logger.error("Puter command execution failed: %s", exc)
+            await self._emit_event(
+                "command_failed",
+                {"command": command, "error": str(exc)},
+            )
+            raise
+
+    async def read_file(self, path: str) -> str:
+        if not self.puter_plugin:
+            raise RuntimeError("PuterTool not initialized")
+        try:
+            content = await self.puter_plugin.read_file(path)
+            await self._emit_event(
+                "file_read", {"path": path, "size": len(content)}
+            )
+            return content
+        except PuterAPIError as exc:
+            logger.error("Failed to read file %s: %s", path, exc)
+            await self._emit_event(
+                "file_read_failed", {"path": path, "error": str(exc)}
+            )
+            raise
+
+    async def write_file(
+        self, path: str, content: str, create_dirs: bool = True
+    ) -> bool:
+        if not self.puter_plugin:
+            raise RuntimeError("PuterTool not initialized")
+        try:
+            result = await self.puter_plugin.write_file(
+                path, content, create_dirs
+            )
+            await self._emit_event(
+                "file_written",
+                {"path": path, "size": len(content), "created_dirs": create_dirs},
+            )
+            return result
+        except PuterAPIError as exc:
+            logger.error("Failed to write file %s: %s", path, exc)
+            await self._emit_event(
+                "file_write_failed", {"path": path, "error": str(exc)}
+            )
+            raise
+
+    async def list_directory(self, path: str = ".") -> List[Dict[str, Any]]:
+        if not self.puter_plugin:
+            raise RuntimeError("PuterTool not initialized")
+        try:
+            items = await self.puter_plugin.list_directory(path)
+            await self._emit_event(
+                "directory_listed",
+                {"path": path, "item_count": len(items)},
+            )
+            return items
+        except PuterAPIError as exc:
+            logger.error("Failed to list directory %s: %s", path, exc)
+            await self._emit_event(
+                "directory_list_failed", {"path": path, "error": str(exc)}
+            )
+            raise
+
+    async def change_directory(self, path: str) -> str:
+        if not self.puter_plugin:
+            raise RuntimeError("PuterTool not initialized")
+        try:
+            old = self.puter_plugin.get_current_directory()
+            new_dir = await self.puter_plugin.change_directory(path)
+            await self._emit_event(
+                "directory_changed",
+                {"old_path": old, "new_path": new_dir},
+            )
+            return new_dir
+        except PuterAPIError as exc:
+            logger.error("Failed to change directory to %s: %s", path, exc)
+            await self._emit_event(
+                "directory_change_failed", {"path": path, "error": str(exc)}
+            )
+            raise
+
+    def get_current_directory(self) -> str:
+        if not self.puter_plugin:
+            raise RuntimeError("PuterTool not initialized")
+        return self.puter_plugin.get_current_directory()
+
+    async def _emit_event(self, event_type: str, data: Dict[str, Any]) -> None:
+        logger.info("Event: %s - %s", event_type, data)
+
+
+class ToolsRegistry:
+    """Registry for computational environment tools."""
+
+    def __init__(self, plugin_registry: PluginRegistry):
+        self.plugin_registry = plugin_registry
+        self.tools: Dict[str, Any] = {}
+
+    async def initialize_tools(self) -> None:
+        if self.plugin_registry.get_plugin("puter"):
+            puter_tool = PuterTool(self.plugin_registry)
+            await puter_tool.initialize()
+            self.tools["puter"] = puter_tool
+            logger.info("Initialized Puter tool")
+
+    def get_tool(self, tool_name: str) -> Optional[Any]:
+        return self.tools.get(tool_name)
+
+    def list_available_tools(self) -> List[str]:
+        return list(self.tools.keys())

--- a/tests/runtime/puter_fakes.py
+++ b/tests/runtime/puter_fakes.py
@@ -1,0 +1,137 @@
+"""
+Fake servers for testing plugin integrations.
+"""
+
+from typing import Any, Dict
+
+from aiohttp import web
+
+
+class FakePuterServer:
+    """Fake Puter server for testing."""
+
+    def __init__(self) -> None:
+        self.files: Dict[str, str] = {
+            "/test/file.txt": "test file content",
+            "/test/readme.md": "# Test README\nThis is a test file.",
+        }
+        self.directories: Dict[str, list[str]] = {
+            "/": ["test"],
+            "/test": ["file.txt", "readme.md"],
+        }
+
+    def create_app(self) -> web.Application:
+        app = web.Application()
+        app.router.add_get("/api/health", self.health_check)
+        app.router.add_get("/api/fs/read", self.read_file)
+        app.router.add_post("/api/fs/write", self.write_file)
+        app.router.add_get("/api/fs/list", self.list_directory)
+        app.router.add_delete("/api/fs/delete", self.delete_file)
+        app.router.add_post("/api/fs/mkdir", self.create_directory)
+        app.router.add_get("/api/fs/stat", self.get_file_stat)
+        app.router.add_post("/api/exec", self.execute_command)
+        return app
+
+    async def health_check(self, request: web.Request) -> web.Response:
+        return web.json_response({"status": "ok"})
+
+    async def read_file(self, request: web.Request) -> web.Response:
+        path = request.query.get("path")
+        if not path or path not in self.files:
+            return web.json_response({"error": "File not found"}, status=404)
+        return web.json_response({"content": self.files[path]})
+
+    async def write_file(self, request: web.Request) -> web.Response:
+        data = await request.json()
+        path = data.get("path")
+        content = data.get("content", "")
+        if not path:
+            return web.json_response({"error": "Path required"}, status=400)
+        self.files[path] = content
+        return web.json_response({"success": True})
+
+    async def list_directory(self, request: web.Request) -> web.Response:
+        path = request.query.get("path", "/")
+        if path not in self.directories:
+            return web.json_response({"error": "Directory not found"}, status=404)
+        items = []
+        for item in self.directories[path]:
+            full = f"{path.rstrip('/')}/{item}"
+            items.append(
+                {
+                    "name": item,
+                    "type": "file" if full in self.files else "directory",
+                    "size": len(self.files.get(full, "")),
+                }
+            )
+        return web.json_response({"items": items})
+
+    async def delete_file(self, request: web.Request) -> web.Response:
+        path = request.query.get("path")
+        if path in self.files:
+            del self.files[path]
+        return web.json_response({"success": True})
+
+    async def create_directory(self, request: web.Request) -> web.Response:
+        data = await request.json()
+        path = data.get("path")
+        if path:
+            self.directories[path] = []
+        return web.json_response({"success": True})
+
+    async def get_file_stat(self, request: web.Request) -> web.Response:
+        path = request.query.get("path")
+        if path in self.files:
+            return web.json_response(
+                {
+                    "type": "file",
+                    "size": len(self.files[path]),
+                    "modified": "2024-01-01T00:00:00Z",
+                }
+            )
+        if path in self.directories:
+            return web.json_response(
+                {
+                    "type": "directory",
+                    "size": 0,
+                    "modified": "2024-01-01T00:00:00Z",
+                }
+            )
+        return web.json_response({"error": "Path not found"}, status=404)
+
+    async def execute_command(self, request: web.Request) -> web.Response:
+        data = await request.json()
+        command = data.get("command")
+        args = data.get("args", [])
+        if command == "echo":
+            stdout = " ".join(args) + "\n"
+            return web.json_response(
+                {
+                    "stdout": stdout,
+                    "stderr": "",
+                    "exit_code": 0,
+                    "execution_time": 0.1,
+                }
+            )
+        if command == "ls":
+            cwd = data.get("cwd", "/")
+            if cwd in self.directories:
+                stdout = "\n".join(self.directories[cwd]) + "\n"
+            else:
+                stdout = ""
+            return web.json_response(
+                {
+                    "stdout": stdout,
+                    "stderr": "",
+                    "exit_code": 0,
+                    "execution_time": 0.05,
+                }
+            )
+        return web.json_response(
+            {
+                "stdout": "",
+                "stderr": f"Command not found: {command}\n",
+                "exit_code": 127,
+                "execution_time": 0.01,
+            }
+        )

--- a/tests/runtime/test_puter_plugin.py
+++ b/tests/runtime/test_puter_plugin.py
@@ -1,0 +1,167 @@
+"""Tests for Puter plugin integration."""
+
+from unittest.mock import AsyncMock, patch
+
+import aiohttp
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import AioHTTPTestCase, unittest_run_loop
+from typing import Any
+
+from src.puter.plugin_registry import PluginRegistry
+from src.puter.puter_plugin import PuterAPIError, PuterPlugin
+from src.puter.tools_registry import PuterTool
+from tests.runtime.puter_fakes import FakePuterServer
+
+
+class TestPuterPlugin(AioHTTPTestCase):
+    async def get_application(self) -> web.Application:  # type: ignore[override]
+        return FakePuterServer().create_app()
+
+    async def setUpAsync(self) -> None:
+        await super().setUpAsync()
+        self.server_url = f"http://localhost:{self.server.port}"
+        self.config = {
+            "base_url": self.server_url,
+            "api_key": "test-api-key",
+            "timeout": 5,
+        }
+        self.plugin = PuterPlugin(self.config)
+        await self.plugin.initialize()
+
+    async def tearDownAsync(self) -> None:
+        await self.plugin.cleanup()
+        await super().tearDownAsync()
+
+    @unittest_run_loop
+    async def test_plugin_initialization(self) -> None:
+        assert self.plugin.session is not None
+        assert self.plugin.base_url == self.server_url
+        assert self.plugin.api_key == "test-api-key"
+
+    @unittest_run_loop
+    async def test_read_file_success(self) -> None:
+        content = await self.plugin.read_file("/test/file.txt")
+        assert content == "test file content"
+
+    @unittest_run_loop
+    async def test_write_file_success(self) -> None:
+        result = await self.plugin.write_file("/test/new_file.txt", "new content")
+        assert result is True
+
+    @unittest_run_loop
+    async def test_execute_command_success(self) -> None:
+        result = await self.plugin.execute_command("echo", ["hello world"])
+        assert result["stdout"] == "hello world\n"
+        assert result["exit_code"] == 0
+
+    @unittest_run_loop
+    async def test_list_directory_success(self) -> None:
+        items = await self.plugin.list_directory("/test")
+        assert isinstance(items, list)
+        assert len(items) > 0
+
+    @unittest_run_loop
+    async def test_change_directory_success(self) -> None:
+        new_dir = await self.plugin.change_directory("/test")
+        assert new_dir == "/test"
+        assert self.plugin.get_current_directory() == "/test"
+
+    @unittest_run_loop
+    async def test_api_error_handling(self) -> None:
+        with pytest.raises(PuterAPIError):
+            await self.plugin.read_file("/nonexistent/file.txt")
+
+
+class TestPuterTool(AioHTTPTestCase):
+    async def get_application(self) -> web.Application:  # type: ignore[override]
+        return FakePuterServer().create_app()
+
+    async def setUpAsync(self) -> None:
+        await super().setUpAsync()
+        self.server_url = f"http://localhost:{self.server.port}"
+        self.registry = PluginRegistry()
+        await self.registry.initialize_plugin(
+            "puter", {"base_url": self.server_url, "api_key": "test-api-key"}
+        )
+        self.tool = PuterTool(self.registry)
+        await self.tool.initialize()
+
+    async def tearDownAsync(self) -> None:
+        await self.registry.cleanup_all()
+        await super().tearDownAsync()
+
+    @unittest_run_loop
+    async def test_tool_initialization(self) -> None:
+        assert self.tool.puter_plugin is not None
+
+    @unittest_run_loop
+    async def test_execute_command_with_events(self) -> None:
+        with patch.object(self.tool, "_emit_event", new_callable=AsyncMock) as mock_emit:
+            result = await self.tool.execute_command("echo", ["test"])
+            assert result["exit_code"] == 0
+            mock_emit.assert_called_once_with(
+                "command_executed",
+                {
+                    "command": "echo",
+                    "args": ["test"],
+                    "exit_code": 0,
+                    "execution_time": result["execution_time"],
+                },
+            )
+
+    @unittest_run_loop
+    async def test_file_operations_with_events(self) -> None:
+        with patch.object(self.tool, "_emit_event", new_callable=AsyncMock) as mock_emit:
+            await self.tool.write_file("/test/file.txt", "content")
+            mock_emit.assert_called_with(
+                "file_written", {"path": "/test/file.txt", "size": 7, "created_dirs": True}
+            )
+            mock_emit.reset_mock()
+            content = await self.tool.read_file("/test/file.txt")
+            mock_emit.assert_called_with(
+                "file_read", {"path": "/test/file.txt", "size": len(content)}
+            )
+
+
+@pytest.mark.asyncio
+async def test_plugin_registry_integration() -> None:
+    registry = PluginRegistry()
+    available = registry.list_available_plugins()
+    assert "puter" in available
+    config = {"base_url": "http://fake-server", "api_key": "test-key"}
+    with patch.object(PuterPlugin, "initialize", new_callable=AsyncMock):
+        await registry.initialize_plugin("puter", config)
+        initialized = registry.list_initialized_plugins()
+        assert "puter" in initialized
+        plugin = registry.get_plugin("puter")
+        assert isinstance(plugin, PuterPlugin)
+    await registry.cleanup_all()
+
+
+@pytest.mark.asyncio
+async def test_error_handling_and_retries() -> None:
+    config = {"base_url": "http://unreachable-server", "api_key": "test-key", "max_retries": 2}
+    plugin = PuterPlugin(config)
+
+    class FailingSession:
+        def __init__(self) -> None:
+            self.request_call_count = 0
+
+        def request(self, *args: Any, **kwargs: Any):
+            self.request_call_count += 1
+
+            class Ctx:
+                async def __aenter__(self_inner):
+                    raise aiohttp.ClientError("Connection failed")
+
+                async def __aexit__(self_inner, exc_type, exc, tb):
+                    return False
+
+            return Ctx()
+
+    session = FailingSession()
+    plugin.session = session  # type: ignore[assignment]
+    with pytest.raises(PuterAPIError):
+        await plugin._make_request("GET", "/api/test")
+    assert session.request_call_count == 3


### PR DESCRIPTION
## Summary
- add Puter plugin and tool registry for remote file and process operations
- provide configuration, example usage, and tests with fake server

## Testing
- `pre-commit run --all-files`
- `pytest -q tests/runtime`


------
https://chatgpt.com/codex/tasks/task_e_68aa80800c0c8328ab37120cc99c80ad