### PR TITLE
[plugins] deduplicate Perplexica search results

### DIFF
--- a/src/plugins/perplexica_search_plugin.py
+++ b/src/plugins/perplexica_search_plugin.py
@@ -381,17 +381,17 @@ class PerplexicaSearchPlugin(PluginInterface):
             return []
 
     def _dedupe_results(self, results: List[SearchResult]) -> List[SearchResult]:
-        """Smart deduplication: same domain+similar title = duplicate."""
+        """Smart deduplication: normalize domains (drop 'www.', ignore ports) and titles."""
         seen: Dict[str, SearchResult] = {}
         deduped: List[SearchResult] = []
 
         for r in results:
-            # Normalize domain: lower-case and strip common "www." prefix
-            domain = urlparse(r.url).netloc.lower()
-            if domain.startswith("www."):
-                domain = domain[4:]
+            # Normalize domain: strip common "www." prefix and ignore ports
+            domain = (
+                (urlparse(r.url).hostname or "").lower().removeprefix("www.")
+            )
 
-            title_sig = r.title[:30].lower()
+            title_sig = r.title.strip().lower()[:30]
             key = f"{domain}:{title_sig}"
 
             if key not in seen:

--- a/src/plugins/perplexica_search_plugin.py
+++ b/src/plugins/perplexica_search_plugin.py
@@ -381,12 +381,16 @@ class PerplexicaSearchPlugin(PluginInterface):
             return []
 
     def _dedupe_results(self, results: List[SearchResult]) -> List[SearchResult]:
-        """Smart deduplication: same domain+similar title = duplicate"""
+        """Smart deduplication: same domain+similar title = duplicate."""
         seen: Dict[str, SearchResult] = {}
         deduped: List[SearchResult] = []
 
         for r in results:
-            domain = urlparse(r.url).netloc
+            # Normalize domain: lower-case and strip common "www." prefix
+            domain = urlparse(r.url).netloc.lower()
+            if domain.startswith("www."):
+                domain = domain[4:]
+
             title_sig = r.title[:30].lower()
             key = f"{domain}:{title_sig}"
 

--- a/tests/plugins/test_perplexica_search_plugin.py
+++ b/tests/plugins/test_perplexica_search_plugin.py
@@ -196,11 +196,11 @@ class TestPerplexicaSearchPlugin:
 
     @pytest.mark.asyncio
     async def test_result_deduplication(self, plugin):
-        """Results with same domain and title are deduplicated."""
+        """Results with same domain (ignoring 'www') and title are deduplicated."""
         raw_results = [
             {
                 "title": "Duplicate Title",
-                "url": "https://example.com/1",
+                "url": "https://www.example.com/1",
                 "snippet": "One",
                 "source": "web",
                 "relevance_score": 0.4,

--- a/tests/plugins/test_perplexica_search_plugin.py
+++ b/tests/plugins/test_perplexica_search_plugin.py
@@ -196,11 +196,11 @@ class TestPerplexicaSearchPlugin:
 
     @pytest.mark.asyncio
     async def test_result_deduplication(self, plugin):
-        """Results with same domain (ignoring 'www') and title are deduplicated."""
+        """Same domain (ignoring 'www' and ports) with similar titles keeps highest score."""
         raw_results = [
             {
                 "title": "Duplicate Title",
-                "url": "https://www.example.com/1",
+                "url": "https://www.example.com:443/1",
                 "snippet": "One",
                 "source": "web",
                 "relevance_score": 0.4,
@@ -228,7 +228,7 @@ class TestPerplexicaSearchPlugin:
         assert len(response.sources) == 2
         urls = [r.url for r in response.sources]
         assert "https://example.com/2" in urls  # higher score kept
-        assert "https://example.com/1" not in urls
+        assert "https://www.example.com:443/1" not in urls
         assert "https://other.com/3" in urls
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- deduplicate PerplexicaSearchPlugin results by domain/title to avoid provider overlap
- add regression test for dedupe behavior

## Changes
- collapse duplicate search results keeping highest relevance
- test ensuring duplicates are pruned and high score retained

## Verification
- `pre-commit run --all-files`
- `pytest tests/plugins/test_perplexica_search_plugin.py::TestPerplexicaSearchPlugin::test_result_deduplication -vv`
- `pytest tests/runtime`

## Runtime impact
- minor CPU work per search to check duplicates; no config changes

## Observability
- no event shape changes; existing telemetry continues to emit

## Rollback
- revert commit `plugins: deduplicate search results`

------
https://chatgpt.com/codex/tasks/task_e_68aa90fa4c0c83288474a76c1e8b7fac