### PR TITLE
core: integrate decision policy

### DIFF
--- a/mcp_server_wrapper.py
+++ b/mcp_server_wrapper.py
@@ -74,3 +74,41 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
+
+# --- Decision Policy Bridge ---
+from src.core.decision_policy_v1 import DecisionPolicyEngine  # noqa: E402
+from src.mcp_local.registry import ToolRegistry as LocalToolRegistry  # noqa: E402
+from typing import Dict  # noqa: E402
+
+
+class MCPBridge:
+    def __init__(self):
+        self.decision_policy = DecisionPolicyEngine()
+        self.mcp_registry = LocalToolRegistry()
+
+    async def register_mcp_tools_as_capabilities(self):
+        for tool_name in self.mcp_registry.list_tools():
+            cap = self._convert_mcp_to_capability(
+                {
+                    "name": tool_name,
+                    "description": f"MCP tool {tool_name}",
+                    "inputSchema": {},
+                }
+            )
+            if hasattr(self.decision_policy, "register_capability"):
+                self.decision_policy.register_capability(cap)  # type: ignore[attr-defined]
+
+    def _create_mcp_executor(self, name: str):
+        async def _exec(**kwargs):
+            return await self.mcp_registry.invoke(name, kwargs)
+
+        return _exec
+
+    def _convert_mcp_to_capability(self, tool_spec: Dict) -> Dict:
+        return {
+            "name": tool_spec["name"],
+            "description": tool_spec.get("description", ""),
+            "parameters": tool_spec.get("inputSchema", {}),
+            "type": "mcp_tool",
+            "executor": self._create_mcp_executor(tool_spec["name"]),
+        }

--- a/src/core/decision_policy_integration.py
+++ b/src/core/decision_policy_integration.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing import Any
+
+from src.core.decision_policy_v1 import DecisionPolicyEngine
+
+try:
+    from src.core.neural_atom import NeuralAtom, NeuralStore  # type: ignore
+except Exception:  # pragma: no cover
+    NeuralStore = object  # type: ignore
+    NeuralAtom = object  # type: ignore
+
+class DecisionPolicyWithMemory:
+    def __init__(self):
+        self.engine = DecisionPolicyEngine()
+        try:
+            self.neural_store = NeuralStore()
+        except Exception:
+            self.neural_store = None
+
+    def register_neural_atom_capability(self, atom: Any):
+        if getattr(atom, "atom_type", "") == "tool" and hasattr(
+            self.engine, "register_capability"
+        ):
+            get_meta = getattr(
+                getattr(atom, "metadata", {}), "get", lambda _k, d=None: d
+            )
+            cap = {
+                "name": f"neural_{getattr(atom, 'atom_id', 'unknown')}",
+                "description": getattr(atom, "description", ""),
+                "type": "neural_capability",
+                "confidence": get_meta("confidence", 0.5),
+            }
+            self.engine.register_capability(cap)  # type: ignore[attr-defined]
+
+    async def enhance_context_with_memory(self, goal_desc: str) -> dict[str, Any]:
+        if not self.neural_store or not hasattr(self.neural_store, "similarity_search"):
+            return {"memories": [], "memory_confidence": 0.0}
+        memories = await self.neural_store.similarity_search(goal_desc, top_k=5)  # type: ignore[attr-defined]
+        return {"memories": memories, "memory_confidence": min(1.0, len(memories)/5.0)}

--- a/src/core/unified_registry.py
+++ b/src/core/unified_registry.py
@@ -1,0 +1,51 @@
+"""
+Unified Capability Registry wrapper across normal, MCP, neural, and dynamic tools.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class Capability:
+    name: str
+    description: str
+    registry_type: str
+    spec: dict[str, Any]
+
+class UnifiedCapabilityRegistry:
+    def __init__(self):
+        self.normal_tools: dict[str, dict[str, Any]] = {}
+        self.mcp_tools: dict[str, dict[str, Any]] = {}
+        self.neural_atoms: dict[str, dict[str, Any]] = {}
+        self.dynamic_tools: dict[str, dict[str, Any]] = {}
+
+    def get_all_capabilities(self) -> list[Capability]:
+        capabilities: list[Capability] = []
+        for registry_name, registry in [
+            ("normal", self.normal_tools),
+            ("mcp", self.mcp_tools),
+            ("neural", self.neural_atoms),
+            ("dynamic", self.dynamic_tools),
+        ]:
+            for name, spec in registry.items():
+                capabilities.append(
+                    Capability(
+                        name=name,
+                        description=spec.get("description", ""),
+                        registry_type=registry_name,
+                        spec=spec,
+                    )
+                )
+        return capabilities
+
+    def register_capability(self, capability: Capability, registry_type: str) -> None:
+        registry_map = {
+            "normal": self.normal_tools,
+            "mcp": self.mcp_tools,
+            "neural": self.neural_atoms,
+            "dynamic": self.dynamic_tools,
+        }
+        if registry_type in registry_map:
+            registry_map[registry_type][capability.name] = capability.spec

--- a/src/core/unified_router.py
+++ b/src/core/unified_router.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from src.core.decision_policy_v1 import DecisionPolicyEngine
+from src.core.execution_flow import REUGExecutionFlow
+
+
+class UnifiedRouter:
+    def __init__(self, event_bus=None, plugin_registry: dict[str, Any] | None = None):
+        self.decision_policy = DecisionPolicyEngine()
+        self.execution_flow = REUGExecutionFlow(
+            event_bus=event_bus, plugin_registry=plugin_registry or {}
+        )
+
+    async def route_request(self, user_input: str, session_id: str):
+        context = {
+            "session_id": session_id,
+            "user_input": user_input,
+            "timestamp": datetime.now(UTC).isoformat(),
+        }
+        plan = await self.decision_policy.decide_and_plan(user_input, context)
+        if hasattr(self.execution_flow, "execute_plan"):
+            return await self.execution_flow.execute_plan(plan)
+        return plan

--- a/tests/core/test_execution_flow_decision_policy.py
+++ b/tests/core/test_execution_flow_decision_policy.py
@@ -1,0 +1,30 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.core.execution_flow import REUGExecutionFlow
+from src.core.states import TransitionTrigger
+
+
+class StubPlan:
+    def __init__(self):
+        self.plan = [{"name": "echo_tool", "args": {"text": "hi"}, "type": "normal"}]
+        self.strategy = "SINGLE_BEST"
+        self.confidence = 0.9
+
+class StubPolicy:
+    async def decide_and_plan(self, _message, _ctx, _budget=None):
+        return StubPlan()
+
+@pytest.mark.asyncio
+async def test_execution_flow_uses_decision_policy():
+    bus = AsyncMock()
+    flow = REUGExecutionFlow(event_bus=bus, plugin_registry={})
+    # Inject stub policy
+    flow.decision_policy = StubPolicy()
+    # Set context
+    flow.state_machine.context.user_input = "hello world"
+    trig = await flow._handle_understand_state()
+    assert trig == TransitionTrigger.TOOLS_ROUTED
+    tools = flow.state_machine.context.tools_selected
+    assert isinstance(tools, list) and tools and tools[0]["name"] == "echo_tool"

--- a/tests/core/test_mcp_bridge.py
+++ b/tests/core/test_mcp_bridge.py
@@ -1,0 +1,10 @@
+from mcp_server_wrapper import MCPBridge
+
+
+def test_mcp_bridge_capability_shape():
+    bridge = MCPBridge()
+    cap = bridge._convert_mcp_to_capability(
+        {"name": "echo", "description": "Echo", "inputSchema": {"type": "object"}}
+    )
+    assert cap["type"] == "mcp_tool"
+    assert callable(bridge._create_mcp_executor("echo"))

--- a/tests/core/test_unified_registry.py
+++ b/tests/core/test_unified_registry.py
@@ -1,0 +1,16 @@
+from src.core.unified_registry import Capability, UnifiedCapabilityRegistry
+
+
+def test_unified_registry_collects_tools():
+    reg = UnifiedCapabilityRegistry()
+    reg.register_capability(
+        Capability("fmt", "Format selection", "normal", {"description": "fmt"}),
+        "normal",
+    )
+    reg.register_capability(
+        Capability("mcp.echo", "Echo", "mcp", {"description": "mcp echo"}),
+        "mcp",
+    )
+    caps = reg.get_all_capabilities()
+    names = sorted([c.name for c in caps])
+    assert names == ["fmt", "mcp.echo"]


### PR DESCRIPTION
## Summary
- hook DecisionPolicyEngine into REUG execution flow
- expose MCP tools to the policy and add lightweight capability registry/router
- cover new integration paths with basic tests

## Changes
- wire DecisionPolicyEngine into `REUGExecutionFlow` and replace legacy routing
- add MCPBridge plus unified capability registry and router helpers
- introduce `DecisionPolicyWithMemory` adapter for neural atoms
- add focused unit tests for decision policy selection, MCP bridge, and registry

## Verification
- `pre-commit run --all-files`
- `pytest tests/runtime`
- `pytest tests/core/test_execution_flow_decision_policy.py tests/core/test_mcp_bridge.py tests/core/test_unified_registry.py`

## Runtime impact
- Decision policy invoked during UNDERSTAND phase; minimal extra latency per turn

## Observability
- no schema changes; existing events continue to emit

## Rollback
- revert commit `core: integrate decision policy`

------
https://chatgpt.com/codex/tasks/task_e_68aade95b9f88328894184e245976cce