### PR TITLE
deepcode: integrate orchestrator and bridge

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,3 +30,6 @@ clean: ## Remove caches and logs
 	find . -type d -name "__pycache__" -exec rm -rf {} +
 	rm -rf .pytest_cache .mypy_cache .coverage coverage.xml htmlcov build dist *.egg-info
 	rm -rf logs/*
+
+deepcode-test:
+	pytest -q tests/plugins/test_deepcode_orchestrator.py tests/test_deepcode_integration.py

--- a/mcp_server/src/mcp_server/tools/deepcode_tool.py
+++ b/mcp_server/src/mcp_server/tools/deepcode_tool.py
@@ -1,0 +1,71 @@
+"""MCP tool for DeepCode repository-level operations (safe, dry-run by default)."""
+from __future__ import annotations
+from pathlib import Path
+from typing import Dict, Any
+import os
+import subprocess
+
+
+def _within_workspace(repo_path: Path, workspace_root: Path) -> bool:
+    try:
+        repo_path = repo_path.resolve()
+        workspace_root = workspace_root.resolve()
+        return os.path.commonpath([repo_path, workspace_root]) == str(workspace_root)
+    except Exception:
+        return False
+
+
+async def execute(params: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Args:
+      action: "generate" | "analyze"
+      repo_path: str
+      prompt: str (for generate)
+      context_window: int (default 16000)
+      dry_run: bool (default True)
+    """
+    action = params.get("action", "analyze").lower()
+    repo_path = Path(params.get("repo_path", "."))
+    dry_run = bool(params.get("dry_run", True))
+    context_window = int(params.get("context_window", 16000))
+    prompt = params.get("prompt", "")
+
+    workspace_root = Path.cwd()
+    if not _within_workspace(repo_path, workspace_root):
+        return {"success": False, "error": f"path {repo_path} is outside workspace"}
+
+    deepcode_dir = Path(os.getenv("DEEPCODE_PATH", "external/DeepCode")).resolve()
+    run_script = deepcode_dir / "run_generation.py"
+
+    if action == "generate":
+        cmd = [
+            "python",
+            str(run_script),
+            "--repo",
+            str(repo_path.resolve()),
+            "--prompt",
+            prompt,
+            "--context-window",
+            str(context_window),
+        ]
+        if dry_run:
+            return {"success": True, "dry_run": True, "command": " ".join(cmd)}
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        return {
+            "success": result.returncode == 0,
+            "stdout": result.stdout,
+            "stderr": result.stderr if result.returncode else None,
+        }
+
+    if action == "analyze":
+        cmd = ["python", str(run_script), "--repo", str(repo_path.resolve()), "--analyze"]
+        if dry_run:
+            return {"success": True, "dry_run": True, "command": " ".join(cmd)}
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        return {
+            "success": result.returncode == 0,
+            "stdout": result.stdout,
+            "stderr": result.stderr if result.returncode else None,
+        }
+
+    return {"success": False, "error": f"unknown action: {action}"}

--- a/src/core/diff_utils.py
+++ b/src/core/diff_utils.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+from dataclasses import dataclass, asdict
+from typing import Dict, Any, List, Optional
+import hashlib
+
+DiffDict = Dict[str, Any]
+
+@dataclass
+class DiffEntry:
+    path: str
+    change_type: str = "modify"   # modify|add|delete
+    unified_diff: str = ""
+    new_content: Optional[str] = None
+    old_sha: Optional[str] = None
+    proposed_by: str = "unknown"
+    confidence: float = 0.0
+
+    def to_dict(self) -> DiffDict:
+        d = asdict(self)
+        if self.new_content is not None:
+            d["new_sha"] = hashlib.sha1(self.new_content.encode("utf-8")).hexdigest()
+        return d
+
+def normalize_diffs(diffs: List[Dict[str, Any]], *, proposed_by: str) -> List[DiffDict]:
+    out: List[DiffDict] = []
+    for d in diffs or []:
+        entry = DiffEntry(
+            path=d.get("path"),
+            change_type=d.get("change_type", "modify"),
+            unified_diff=d.get("unified_diff") or d.get("diff") or "",
+            new_content=d.get("new_content"),
+            old_sha=d.get("old_sha"),
+            proposed_by=proposed_by,
+            confidence=float(d.get("confidence", 0.0)),
+        )
+        if not entry.path:
+            raise ValueError("diff entry missing path")
+        out.append(entry.to_dict())
+    return out

--- a/src/plugins/deepcode_events.py
+++ b/src/plugins/deepcode_events.py
@@ -1,0 +1,28 @@
+"""DeepCode-specific event metadata helper."""
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import List, Dict, Any
+from datetime import datetime, timezone
+import hashlib
+
+
+@dataclass
+class DeepCodeGenerationEvent:
+    repo_path: str
+    prompt: str
+    context_files: List[str]
+    timestamp: datetime | None = None
+
+    def __post_init__(self):
+        if self.timestamp is None:
+            self.timestamp = datetime.now(timezone.utc)
+
+    def to_atom_metadata(self) -> Dict[str, Any]:
+        prompt_hash = hashlib.sha256(self.prompt.encode("utf-8")).hexdigest()[:16]
+        return {
+            "event_type": "deepcode_generation",
+            "repo_path": self.repo_path,
+            "prompt_hash": prompt_hash,
+            "context_size": len(self.context_files),
+            "timestamp": self.timestamp.isoformat(),
+        }

--- a/src/plugins/deepcode_generator_plugin.py
+++ b/src/plugins/deepcode_generator_plugin.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict
+
+from src.core.plugin_interface import PluginInterface
+
+logger = logging.getLogger(__name__)
+
+
+def _utcnow() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+class DeepCodeGeneratorBridgePlugin(PluginInterface):
+    """
+    Bridge plugin accepting legacy Super Alita requests and forwarding them
+    into the normalized DeepCode orchestrator pipeline as `deepcode_request`.
+
+    Listens:
+      - code_generation_request
+      - repository_analysis_request
+
+    Emits:
+      - deepcode_request
+      - cognitive_turn (breadcrumb)
+    """
+    @property
+    def name(self) -> str:
+        return "deepcode_generator"
+
+    async def setup(self, event_bus: Any, store: Any, config: Dict[str, Any]) -> None:
+        await super().setup(event_bus, store, config)
+        logger.info("DeepCodeGeneratorBridge setup complete")
+
+    async def start(self) -> None:
+        await super().start()
+        await self.subscribe("code_generation_request", self._handle_generation)
+        await self.subscribe("repository_analysis_request", self._handle_analysis)
+        logger.info("DeepCodeGeneratorBridge started (listening for legacy events)")
+
+    async def shutdown(self) -> None:
+        logger.info("DeepCodeGeneratorBridge shutting down")
+        await super().shutdown()
+
+    async def _handle_generation(self, event: Dict[str, Any]) -> None:
+        if not self.is_running:
+            return
+        prompt = event.get("prompt") or event.get("data", {}).get("prompt") or ""
+        repo_path = event.get("repo_path") or event.get("data", {}).get("repo_path") or "."
+        conversation_id = event.get("conversation_id")
+
+        await self.emit_event(
+            "cognitive_turn",
+            source_plugin=self.name,
+            stage="deepcode_bridge_processing",
+            confidence=0.85,
+            conversation_id=conversation_id,
+            timestamp=_utcnow(),
+        )
+        await self.emit_event(
+            "deepcode_request",
+            source_plugin=self.name,
+            task_kind="text2backend",
+            requirements=prompt,
+            repo_path=repo_path,
+            conversation_id=conversation_id,
+            timestamp=_utcnow(),
+        )
+
+    async def _handle_analysis(self, event: Dict[str, Any]) -> None:
+        if not self.is_running:
+            return
+        repo_path = event.get("repo_path") or "."
+        conversation_id = event.get("conversation_id")
+        await self.emit_event(
+            "deepcode_request",
+            source_plugin=self.name,
+            task_kind="analyze",
+            requirements=f"Analyze repository at {repo_path}",
+            repo_path=repo_path,
+            conversation_id=conversation_id,
+            timestamp=_utcnow(),
+        )
+
+def create_plugin():
+    return DeepCodeGeneratorBridgePlugin()

--- a/src/plugins/deepcode_orchestrator_plugin.py
+++ b/src/plugins/deepcode_orchestrator_plugin.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import asyncio
+import json
+import logging
+from datetime import datetime, timezone
+from hashlib import sha256
+from typing import Any, Dict, List, Optional
+
+from src.core.plugin_interface import PluginInterface
+try:
+    from src.core.observability import ObservabilityManager  # type: ignore
+except Exception:  # pragma: no cover
+    ObservabilityManager = None  # type: ignore
+
+from src.core.diff_utils import normalize_diffs
+
+logger = logging.getLogger(__name__)
+
+
+def _utcnow() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+class DeepCodeClientInterface:
+    async def plan(self, request: Dict[str, Any]) -> Dict[str, Any]: ...
+    async def collect_references(self, plan: Dict[str, Any]) -> Dict[str, Any]: ...
+    async def generate_code(self, plan: Dict[str, Any], references: Dict[str, Any]) -> Dict[str, Any]: ...
+    async def validate(self, implementation: Dict[str, Any]) -> Dict[str, Any]: ...
+
+
+class _StubDeepCodeClient(DeepCodeClientInterface):
+    async def plan(self, request: Dict[str, Any]) -> Dict[str, Any]:
+        return {"steps": ["draft plan", "produce impl"], "confidence": 0.73, "request": request}
+    async def collect_references(self, plan: Dict[str, Any]) -> Dict[str, Any]:
+        return {"snippets": [], "confidence": 0.78}
+    async def generate_code(self, plan: Dict[str, Any], references: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            "proposal_id": None,
+            "diffs": [{
+                "path": "docs/deepcode_result.md",
+                "change_type": "add",
+                "unified_diff": "--- /dev/null\n+++ b/docs/deepcode_result.md\n@@\n+# Result\n+Hello DeepCode\n",
+                "new_content": "# Result\n\nHello DeepCode\n",
+                "confidence": 0.84
+            }],
+            "tests": [{"path": "tests/test_deepcode_result.py", "content": "def test_ok(): assert True"}],
+            "docs": [{"path": "docs/plan.json", "content": json.dumps(plan)}],
+            "confidence": 0.84
+        }
+    async def validate(self, implementation: Dict[str, Any]) -> Dict[str, Any]:
+        return {"status": "pass", "lint_errors": 0, "tests_passed": True, "confidence": 0.91}
+
+
+class DeepCodeOrchestratorPlugin(PluginInterface):
+    """
+    Orchestrates DeepCode multi-phase generation inside Super-Alita.
+    Events (snake_case):
+      - deepcode_request_received
+      - deepcode_plan_ready
+      - deepcode_references_compiled
+      - deepcode_implementation_proposed
+      - deepcode_validation_report
+      - deepcode_ready_for_apply
+      - deepcode_pipeline_failed
+    """
+    def __init__(self, client: DeepCodeClientInterface | None = None):
+        super().__init__()
+        self._client = client or _StubDeepCodeClient()
+        self._active: Dict[str, Dict[str, Any]] = {}
+        self._tasks: set[asyncio.Task] = set()
+        self._obs: Optional[ObservabilityManager] = None  # type: ignore[name-defined]
+
+    @property
+    def name(self) -> str:
+        return "deepcode_orchestrator"
+
+    async def setup(self, event_bus: Any, store: Any, config: Dict[str, Any]) -> None:
+        await super().setup(event_bus, store, config)
+        self._obs = config.get("observability_manager") if isinstance(config, dict) else None
+        logger.info("DeepCode Orchestrator setup complete")
+
+    async def start(self) -> None:
+        await super().start()
+        await self.subscribe("deepcode_request", self._on_request)
+        logger.info("DeepCode Orchestrator started (listening for deepcode_request)")
+
+    async def shutdown(self) -> None:
+        logger.info("DeepCode Orchestrator shutting down")
+        for t in list(self._tasks):
+            t.cancel()
+        await asyncio.gather(*self._tasks, return_exceptions=True)
+        self._tasks.clear()
+        await super().shutdown()
+
+    async def stop(self) -> None:
+        await self.shutdown()
+
+    async def _on_request(self, event: Dict[str, Any]) -> None:
+        if not self.is_running:
+            return
+        request_id = event.get("request_id") or f"dc_req_{int(datetime.now(timezone.utc).timestamp()*1000)}"
+        conversation_id = event.get("conversation_id")
+        task_kind = event.get("task_kind", "generic")
+        requirements = event.get("requirements", "")
+        correlation_id = event.get("correlation_id")
+
+        self._active[request_id] = {
+            "task_kind": task_kind,
+            "requirements": requirements,
+            "conversation_id": conversation_id,
+            "started_at": _utcnow(),
+            "correlation_id": correlation_id,
+        }
+        await self.emit_event(
+            "deepcode_request_received",
+            source_plugin=self.name,
+            request_id=request_id,
+            task_kind=task_kind,
+            conversation_id=conversation_id,
+            correlation_id=correlation_id,
+            timestamp=_utcnow(),
+        )
+        task = asyncio.create_task(self._run_pipeline(request_id))
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
+
+    async def _run_pipeline(self, request_id: str) -> None:
+        ctx = self._active.get(request_id)
+        if not ctx:
+            return
+        conversation_id = ctx["conversation_id"]
+        correlation_id = ctx.get("correlation_id")
+        base_req = {"task_kind": ctx["task_kind"], "requirements": ctx["requirements"], "request_id": request_id}
+        try:
+            plan = await self._phase("planning", self._client.plan, base_req)
+            await self.emit_event(
+                "deepcode_plan_ready",
+                source_plugin=self.name,
+                request_id=request_id,
+                conversation_id=conversation_id,
+                correlation_id=correlation_id,
+                timestamp=_utcnow(),
+                plan=plan,
+                confidence=float(plan.get("confidence", 0.72)),
+            )
+            refs = await self._phase("reference_collection", self._client.collect_references, plan)
+            await self.emit_event(
+                "deepcode_references_compiled",
+                source_plugin=self.name,
+                request_id=request_id,
+                conversation_id=conversation_id,
+                correlation_id=correlation_id,
+                timestamp=_utcnow(),
+                references=refs,
+                reference_count=len(refs.get("snippets", [])),
+                confidence=float(refs.get("confidence", 0.78)),
+            )
+            impl = await self._phase("implementation_generation", self._client.generate_code, plan, refs)
+            pid = impl.get("proposal_id")
+            if not pid:
+                pid = "dc_prop_" + sha256(
+                    (json.dumps(plan, sort_keys=True) + "|" + json.dumps(refs, sort_keys=True) + "|" + request_id).encode("utf-8")
+                ).hexdigest()[:16]
+            diffs = normalize_diffs(impl.get("diffs", []), proposed_by=self.name)
+            await self.emit_event(
+                "deepcode_implementation_proposed",
+                source_plugin=self.name,
+                request_id=request_id,
+                proposal_id=pid,
+                conversation_id=conversation_id,
+                correlation_id=correlation_id,
+                timestamp=_utcnow(),
+                diffs=diffs,
+                tests=impl.get("tests", []),
+                docs=impl.get("docs", []),
+                confidence=float(impl.get("confidence", 0.84)),
+                dry_run=True,
+            )
+            validation = await self._phase("validation", self._client.validate, {"proposal_id": pid, "diffs": diffs})
+            success = validation.get("status") == "pass"
+            await self.emit_event(
+                "deepcode_validation_report",
+                source_plugin=self.name,
+                request_id=request_id,
+                proposal_id=pid,
+                conversation_id=conversation_id,
+                correlation_id=correlation_id,
+                timestamp=_utcnow(),
+                validation=validation,
+                success=bool(success),
+                confidence=float(validation.get("confidence", 0.9)),
+            )
+            if success:
+                await self.emit_event(
+                    "deepcode_ready_for_apply",
+                    source_plugin=self.name,
+                    request_id=request_id,
+                    proposal_id=pid,
+                    conversation_id=conversation_id,
+                    correlation_id=correlation_id,
+                    timestamp=_utcnow(),
+                    diffs=diffs,
+                    validation_summary={
+                        "lint_errors": validation.get("lint_errors", 0),
+                        "tests_passed": validation.get("tests_passed", True),
+                    },
+                )
+        except asyncio.CancelledError:
+            await self.emit_event(
+                "deepcode_pipeline_failed",
+                source_plugin=self.name,
+                request_id=request_id,
+                conversation_id=conversation_id,
+                correlation_id=correlation_id,
+                timestamp=_utcnow(),
+                error="cancelled",
+            )
+            raise
+        except Exception as e:
+            logger.exception("DeepCode pipeline error")
+            await self.emit_event(
+                "deepcode_pipeline_failed",
+                source_plugin=self.name,
+                request_id=request_id,
+                conversation_id=conversation_id,
+                correlation_id=correlation_id,
+                timestamp=_utcnow(),
+                error=str(e),
+            )
+
+    async def _phase(self, name: str, func, *args, **kwargs) -> Dict[str, Any]:
+        if self._obs:
+            try:
+                async with self._obs.trace_operation(f"deepcode_{name}"):
+                    return await func(*args, **kwargs)
+            except Exception:
+                return await func(*args, **kwargs)
+        return await func(*args, **kwargs)
+
+    def get_tools(self):
+        return [{
+            "name": "deepcode_request",
+            "description": "Trigger a DeepCode generation flow (paper2code/text2web/text2backend). Emits diff-first proposal.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "task_kind": {"type": "string", "description": "paper2code | text2web | text2backend | generic"},
+                    "requirements": {"type": "string", "description": "Raw textual requirement or summary"},
+                    "conversation_id": {"type": "string", "description": "Conversation/session identifier"},
+                },
+                "required": ["task_kind", "requirements"],
+                "additionalProperties": False
+            },
+            "cost_hint": "medium",
+            "latency_hint": "high",
+            "safety_level": "medium",
+            "test_reference": "tests/plugins/test_deepcode_orchestrator.py::test_emits_full_sequence",
+            "category": "implementation",
+            "complexity": "advanced",
+            "version": "0.1.1",
+            "dependencies": ["deepcode-hku (optional)"]
+            ,
+            "integration_requirements": "Diff-first only; apply gated by guardian/compliance route"
+        }]
+
+def create_plugin():
+    return DeepCodeOrchestratorPlugin()

--- a/tests/plugins/test_deepcode_orchestrator.py
+++ b/tests/plugins/test_deepcode_orchestrator.py
@@ -1,0 +1,64 @@
+import asyncio
+import pytest
+from typing import Any, Dict
+
+from src.plugins.deepcode_orchestrator_plugin import DeepCodeOrchestratorPlugin, DeepCodeClientInterface
+
+
+class FakeBus:
+    async def subscribe(self, event_type: str, handler):
+        return None
+
+
+class FakeDC(DeepCodeClientInterface):
+    async def plan(self, req: Dict[str, Any]) -> Dict[str, Any]:
+        return {"steps": ["A", "B"], "confidence": 0.72}
+
+    async def collect_references(self, plan: Dict[str, Any]) -> Dict[str, Any]:
+        return {"snippets": [{"path": "x.py", "code": "print(1)"}], "confidence": 0.79}
+
+    async def generate_code(self, plan: Dict[str, Any], refs: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            "proposal_id": "prop123",
+            "diffs": [
+                {
+                    "path": "x.py",
+                    "unified_diff": "--- a\n+++ b\n",
+                    "new_content": "print(2)",
+                    "confidence": 0.85,
+                }
+            ],
+            "tests": [],
+            "docs": [],
+            "confidence": 0.85,
+        }
+
+    async def validate(self, impl: Dict[str, Any]) -> Dict[str, Any]:
+        return {"status": "pass", "lint_errors": 0, "tests_passed": True, "confidence": 0.9}
+
+
+@pytest.mark.asyncio
+async def test_emits_full_sequence(monkeypatch):
+    events = []
+
+    class P(DeepCodeOrchestratorPlugin):
+        async def emit_event(self, event_type: str, **fields):
+            events.append({"event_type": event_type, **fields})
+            return await super().emit_event(event_type, **fields)
+
+    plugin = P(client=FakeDC())
+    await plugin.setup(event_bus=FakeBus(), store=None, config={})
+    await plugin.start()
+
+    await plugin._on_request(
+        {"request_id": "req1", "task_kind": "paper2code", "requirements": "do X", "conversation_id": "c1"}
+    )
+    await asyncio.sleep(0.05)
+
+    kinds = [e["event_type"] for e in events]
+    assert "deepcode_request_received" in kinds
+    assert "deepcode_plan_ready" in kinds
+    assert "deepcode_references_compiled" in kinds
+    assert "deepcode_implementation_proposed" in kinds
+    assert "deepcode_validation_report" in kinds
+    assert "deepcode_ready_for_apply" in kinds

--- a/tests/test_deepcode_integration.py
+++ b/tests/test_deepcode_integration.py
@@ -1,0 +1,41 @@
+import asyncio
+import pytest
+from src.plugins.deepcode_generator_plugin import DeepCodeGeneratorBridgePlugin
+
+
+class FakeBus:
+    async def subscribe(self, event_type: str, handler):
+        return None
+
+
+@pytest.mark.asyncio
+async def test_bridge_initialization():
+    plugin = DeepCodeGeneratorBridgePlugin()
+    await plugin.setup(event_bus=FakeBus(), store=None, config={})
+    assert plugin.name == "deepcode_generator"
+
+
+@pytest.mark.asyncio
+async def test_generation_event_bridges_to_deepcode_request(monkeypatch):
+    captured = []
+
+    class P(DeepCodeGeneratorBridgePlugin):
+        async def emit_event(self, event_type: str, **fields):
+            captured.append({"event_type": event_type, **fields})
+            return await super().emit_event(event_type, **fields)
+
+    plugin = P()
+    await plugin.setup(event_bus=FakeBus(), store=None, config={})
+    await plugin.start()
+    await plugin._handle_generation({
+        "prompt": "Create a FastAPI endpoint",
+        "repo_path": ".",
+        "conversation_id": "conv1",
+    })
+    await asyncio.sleep(0.01)
+    kinds = [e["event_type"] for e in captured]
+    assert "cognitive_turn" in kinds
+    assert "deepcode_request" in kinds
+    reqs = [e for e in captured if e["event_type"] == "deepcode_request"][0]
+    assert reqs["task_kind"] == "text2backend"
+    assert reqs["requirements"].startswith("Create a FastAPI")


### PR DESCRIPTION
## Summary
- add diff utilities and DeepCode orchestrator/bridge plugins
- expose DeepCode MCP tool and test harness

## Changes
- normalize diff entries with `DiffEntry` dataclass
- orchestrate DeepCode planning→validation pipeline with deterministic proposal IDs
- bridge legacy generation events into `deepcode_request`
- add Dry-run MCP tool and Makefile test target

## Verification
- `pre-commit run --all-files`
- `pytest -q tests/runtime`
- `make deepcode-test`

## Runtime impact
- registers `deepcode_request` tool; pipeline runs asynchronously and remains dry-run until approved

## Observability
- emits `deepcode_*` lifecycle events and `cognitive_turn` breadcrumbs for DeepCode flows

## Rollback
- revert this commit or disable DeepCode plugins in the loader configuration


------
https://chatgpt.com/codex/tasks/task_e_68ab42a6a9308328900eb271785dec1e