### PR TITLE
[codegen] Add Gemini codegen ability and adapters

### DIFF
--- a/src/abilities/__init__.py
+++ b/src/abilities/__init__.py
@@ -1,0 +1,1 @@
+"""Abilities package marker."""

--- a/src/abilities/gemini_codegen_ability.py
+++ b/src/abilities/gemini_codegen_ability.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import json
+import logging
+import os
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Tuple
+
+import aiohttp
+from src.core.plugin_interface import PluginInterface
+
+logger = logging.getLogger(__name__)
+
+
+def _utcnow() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _norm(s: str) -> str:
+    return " ".join((s or "").strip().split())
+
+
+NAMESPACE_PROPOSAL = uuid.UUID("d6e2a8b1-4c7f-4e0a-8b9c-1d2e3f4a5b6c")
+
+
+@dataclass
+class GeminiConfig:
+    api_key: Optional[str]
+    model: str
+    enabled: bool
+
+
+class GeminiCodegenAbility(PluginInterface):
+    """Generate diffs/tests/docs from requirements using Gemini."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._cfg = GeminiConfig(
+            api_key=os.getenv("GEMINI_API_KEY"),
+            model=os.getenv("GEMINI_MODEL", "gemini-1.5-pro"),
+            enabled=os.getenv("CODEGEN_ENABLED", "true").lower() == "true",
+        )
+
+    async def setup(self, event_bus: Any, store: Any, config: Dict[str, Any]) -> None:
+        await super().setup(event_bus, store, config)
+
+    @property
+    def name(self) -> str:
+        return "gemini_codegen_ability"
+
+    async def start(self) -> None:
+        await super().start()
+        if not self._cfg.enabled:
+            logger.info("GeminiCodegenAbility disabled; not starting.")
+            return
+        await self.subscribe("codegen_request", self._on_request)
+        logger.info(
+            "GeminiCodegenAbility started (model=%s, key=%s)",
+            self._cfg.model,
+            bool(self._cfg.api_key),
+        )
+
+    async def _on_request(self, event: Dict[str, Any]) -> None:
+        requirements = _norm(event.get("requirements") or "")
+        repo_path = event.get("repo_path") or "."
+        context_files = event.get("context_files") or []
+        proposal_id = str(
+            uuid.uuid5(
+                NAMESPACE_PROPOSAL,
+                f"{requirements}|{repo_path}|{','.join(context_files)}",
+            )
+        )
+
+        if not self._cfg.api_key:
+            diffs = [self._fake_diff(requirements)]
+            tests = [self._fake_test(requirements)]
+            await self.emit_event(
+                "codegen_implementation_proposed",
+                event_type="codegen_implementation_proposed",
+                source_plugin=self.name,
+                proposal_id=proposal_id,
+                diffs=diffs,
+                tests=tests,
+                docs=[],
+                confidence=0.4,
+                **{k: v for k, v in event.items() if k.endswith("_id")},
+                timestamp=_utcnow(),
+            )
+            return
+
+        try:
+            diffs, tests, docs, confidence = await self._call_gemini(
+                requirements, repo_path, context_files
+            )
+        except Exception as e:  # pragma: no cover
+            logger.warning("Gemini call failed: %s", e)
+            diffs, tests, docs, confidence = [
+                self._fake_diff(requirements)
+            ], [
+                self._fake_test(requirements)
+            ], [], 0.3
+
+        await self.emit_event(
+            "codegen_implementation_proposed",
+            event_type="codegen_implementation_proposed",
+            source_plugin=self.name,
+            proposal_id=proposal_id,
+            diffs=diffs,
+            tests=tests,
+            docs=docs,
+            confidence=confidence,
+            **{k: v for k, v in event.items() if k.endswith("_id")},
+            timestamp=_utcnow(),
+        )
+
+    async def _call_gemini(
+        self,
+        requirements: str,
+        repo_path: str,
+        context_files: List[str],
+    ) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]], List[Dict[str, Any]], float]:
+        url = (
+            "https://generativelanguage.googleapis.com/v1beta/models/"
+            f"{self._cfg.model}:generateContent?key={self._cfg.api_key}"
+        )
+        sys_message = (
+            "You are a repository-level code generation assistant. "
+            "Return STRICT JSON with keys: diffs (list), tests (list), docs (list), confidence (float). "
+            "Diffs entries MUST have {\"path\": str, \"patch\": str}. "
+            "Tests/docs entries MUST have {\"path\": str, \"content\": str}. "
+            "Do not include explanations or code fences."
+        )
+        user_message = {
+            "requirements": requirements,
+            "repo_path": repo_path,
+            "context_files": context_files,
+        }
+        payload = {
+            "contents": [
+                {"role": "user", "parts": [{"text": sys_message}]},
+                {"role": "user", "parts": [{"text": json.dumps(user_message)}]},
+            ],
+            "generationConfig": {
+                "temperature": 0.2,
+                "maxOutputTokens": 4096,
+                "responseMimeType": "application/json",
+            },
+        }
+        async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=60)) as s:
+            async with s.post(url, json=payload) as resp:
+                txt = await resp.text()
+                if resp.status >= 300:
+                    raise RuntimeError(f"Gemini HTTP {resp.status}: {txt[:200]}")
+                data = json.loads(txt)
+        try:
+            raw = data["candidates"][0]["content"]["parts"][0]["text"]
+            obj = json.loads(raw)
+        except Exception:
+            obj = data if isinstance(data, dict) else {
+                "diffs": [],
+                "tests": [],
+                "docs": [],
+                "confidence": 0.5,
+            }
+        diffs = obj.get("diffs") or []
+        tests = obj.get("tests") or []
+        docs = obj.get("docs") or []
+        confidence = float(obj.get("confidence") or 0.5)
+        return diffs, tests, docs, confidence
+
+    def _fake_diff(self, requirements: str) -> Dict[str, Any]:
+        return {
+            "path": "README.md",
+            "patch": (
+                "--- a/README.md\n" "+++ b/README.md\n" "@@\n" f"+AUTO-GENERATED NOTE: {requirements}\n"
+            ),
+        }
+
+    def _fake_test(self, requirements: str) -> Dict[str, Any]:
+        return {
+            "path": "tests/test_codegen_placeholder.py",
+            "content": (
+                "def test_codegen_placeholder():\n"
+                f"    assert '{requirements[:20]}' is not None\n"
+            ),
+        }

--- a/src/plugins/dify_adapter_plugin.py
+++ b/src/plugins/dify_adapter_plugin.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import logging
+import os
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+import aiohttp
+from src.core.plugin_interface import PluginInterface
+
+logger = logging.getLogger(__name__)
+
+
+def _utcnow() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+@dataclass
+class DifyConfig:
+    api_url: str
+    api_key: Optional[str] = None
+    workflow_id: Optional[str] = None
+    enable_streaming: bool = True
+    use_codegen_for_code: bool = True
+    enabled: bool = False
+
+
+class DifyAdapterPlugin(PluginInterface):
+    """Bridge Dify requests to generic codegen events."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._session: aiohttp.ClientSession | None = None
+        self._cfg = DifyConfig(
+            api_url=os.getenv("DIFY_API_URL", "http://localhost:3000/api"),
+            api_key=os.getenv("DIFY_API_KEY"),
+            workflow_id=os.getenv("DIFY_WORKFLOW_ID") or None,
+            enable_streaming=os.getenv("DIFY_STREAMING", "true").lower() == "true",
+            use_codegen_for_code=os.getenv("DIFY_USE_CODEGEN", "true").lower()
+            == "true",
+            enabled=os.getenv("DIFY_ENABLED", "false").lower() == "true",
+        )
+
+    @property
+    def name(self) -> str:
+        return "dify_adapter"
+
+    async def setup(
+        self, event_bus: Any, store: Any, config: Dict[str, Any]
+    ) -> None:
+        await super().setup(event_bus, store, config)
+        logger.info("DifyAdapter setup (enabled=%s)", self._cfg.enabled)
+
+    async def start(self) -> None:
+        await super().start()
+        if not self._cfg.enabled:
+            logger.info("DifyAdapter disabled; not subscribing.")
+            return
+        self._session = aiohttp.ClientSession()
+        await self.subscribe("dify_request", self._on_dify_request)
+        await self.subscribe("codegen_implementation_proposed", self._on_codegen_result)
+        await self.subscribe("codegen_ready_for_apply", self._on_codegen_result)
+        logger.info("DifyAdapter started")
+
+    async def shutdown(self) -> None:
+        logger.info("DifyAdapter shutting down")
+        if self._session:
+            await self._session.close()
+        await super().shutdown()
+
+    async def _on_dify_request(self, event: Dict[str, Any]) -> None:
+        if not self.is_running or not self._cfg.enabled:
+            return
+        action = (event.get("action") or "generate_code").lower()
+        if action == "generate_code" and self._cfg.use_codegen_for_code:
+            await self.emit_event(
+                "codegen_request",
+                source_plugin=self.name,
+                task_kind="text2backend",
+                requirements=event.get("prompt") or "",
+                repo_path=event.get("repo_path") or ".",
+                context_files=event.get("context_files") or [],
+                dify_callback_id=event.get("dify_callback_id"),
+                conversation_id=event.get("conversation_id"),
+                timestamp=_utcnow(),
+            )
+        else:
+            await self.emit_event(
+                "dify_callback_completed",
+                source_plugin=self.name,
+                info=f"action {action} routed internally (not codegen)",
+                timestamp=_utcnow(),
+            )
+
+    async def _on_codegen_result(self, event: Dict[str, Any]) -> None:
+        if not self._session:
+            return
+        callback_id = event.get("dify_callback_id") or event.get("data", {}).get(
+            "dify_callback_id"
+        )
+        if not callback_id:
+            return
+        payload = {
+            "callback_id": callback_id,
+            "result": {
+                "event_type": event.get("event_type"),
+                "proposal_id": event.get("proposal_id"),
+                "diffs": event.get("diffs", []),
+                "tests": event.get("tests", []),
+                "docs": event.get("docs", []),
+                "validation": event.get("validation"),
+                "success": event.get("success", None),
+                "confidence": event.get("confidence", None),
+                "timestamp": _utcnow(),
+            },
+        }
+        try:
+            async with self._session.post(
+                f"{self._cfg.api_url}/callbacks/{callback_id}",
+                json=payload,
+                headers={
+                    "Authorization": f"Bearer {self._cfg.api_key}"
+                }
+                if self._cfg.api_key
+                else None,
+                timeout=aiohttp.ClientTimeout(total=20),
+            ) as resp:
+                await resp.text()
+                await self.emit_event(
+                    "dify_callback_completed",
+                    source_plugin=self.name,
+                    status=resp.status,
+                    callback_id=callback_id,
+                    timestamp=_utcnow(),
+                )
+        except Exception as e:
+            logger.warning("Dify callback failed: %s", e)

--- a/src/plugins/flowise_adapter_plugin.py
+++ b/src/plugins/flowise_adapter_plugin.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+import json
+import logging
+import os
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+import asyncio
+import contextlib
+import websockets
+from src.core.plugin_interface import PluginInterface
+
+logger = logging.getLogger(__name__)
+
+
+def _utcnow() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+@dataclass
+class FlowiseConfig:
+    ws_url: str
+    api_key: Optional[str] = None
+    enabled: bool = False
+
+
+class FlowiseAdapterPlugin(PluginInterface):
+    """Flowise <-> Super Alita adapter for codegen events."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._cfg = FlowiseConfig(
+            ws_url=os.getenv("FLOWISE_WS_URL", "ws://localhost:3000"),
+            api_key=os.getenv("FLOWISE_API_KEY"),
+            enabled=os.getenv("FLOWISE_ENABLED", "false").lower() == "true",
+        )
+        self._ws: websockets.WebSocketClientProtocol | None = None
+        self._listener_task: asyncio.Task | None = None
+
+    @property
+    def name(self) -> str:
+        return "flowise_adapter"
+
+    async def start(self) -> None:
+        await super().start()
+        if not self._cfg.enabled:
+            logger.info("FlowiseAdapter disabled; not starting.")
+            return
+        await self.subscribe("codegen_implementation_proposed", self._on_codegen_event)
+        await self.subscribe("codegen_ready_for_apply", self._on_codegen_event)
+        self._listener_task = asyncio.create_task(self._connect_and_listen())
+        logger.info("FlowiseAdapter started")
+
+    async def shutdown(self) -> None:
+        logger.info("FlowiseAdapter shutting down")
+        if self._listener_task:
+            self._listener_task.cancel()
+            with contextlib.suppress(Exception):
+                await self._listener_task
+        if self._ws:
+            with contextlib.suppress(Exception):
+                await self._ws.close()
+        await super().shutdown()
+
+    async def _connect_and_listen(self) -> None:
+        headers = {"Authorization": f"Bearer {self._cfg.api_key}"} if self._cfg.api_key else None
+        while self.is_running:
+            try:
+                async with websockets.connect(self._cfg.ws_url, extra_headers=headers) as ws:
+                    self._ws = ws
+                    await self._register_node(ws)
+                    async for raw in ws:
+                        try:
+                            data = json.loads(raw)
+                        except Exception:
+                            continue
+                        await self._handle_inbound(data)
+            except Exception as e:
+                logger.warning("Flowise WS error: %s; retrying in 2s", e)
+                await asyncio.sleep(2)
+
+    async def _register_node(self, ws: websockets.WebSocketClientProtocol) -> None:
+        node_def = {
+            "type": "register_node",
+            "data": {
+                "name": "Codegen Generator",
+                "class": "CodegenNode",
+                "description": "Repo-level code generation via Gemini",
+                "inputs": [
+                    {"label": "Prompt", "name": "prompt", "type": "string"},
+                    {
+                        "label": "Repository Path",
+                        "name": "repoPath",
+                        "type": "string",
+                        "optional": True,
+                        "default": ".",
+                    },
+                    {
+                        "label": "Context Files",
+                        "name": "contextFiles",
+                        "type": "string",
+                        "optional": True,
+                    },
+                ],
+                "outputs": [
+                    {"label": "Generated Diffs", "name": "diffs", "type": "json"},
+                    {"label": "Tests", "name": "tests", "type": "json"},
+                ],
+            },
+        }
+        await ws.send(json.dumps(node_def))
+
+    async def _handle_inbound(self, msg: Dict[str, Any]) -> None:
+        mtype = msg.get("type")
+        if mtype == "execute_node" and msg.get("node") == "CodegenNode":
+            inputs = msg.get("inputs") or {}
+            session_id = msg.get("sessionId")
+            await self.emit_event(
+                "codegen_request",
+                source_plugin=self.name,
+                task_kind="text2backend",
+                requirements=inputs.get("prompt") or "",
+                repo_path=inputs.get("repoPath") or ".",
+                context_files=(inputs.get("contextFiles") or "").splitlines()
+                if inputs.get("contextFiles")
+                else [],
+                flowise_session_id=session_id,
+                timestamp=_utcnow(),
+            )
+        elif mtype == "chat_message":
+            message = msg.get("message") or ""
+            session_id = msg.get("sessionId")
+            if any(k in message.lower() for k in ("generate", "create", "implement", "write code")):
+                await self.emit_event(
+                    "codegen_request",
+                    source_plugin=self.name,
+                    task_kind="text2backend",
+                    requirements=message,
+                    flowise_session_id=session_id,
+                    timestamp=_utcnow(),
+                )
+
+    async def _on_codegen_event(self, event: Dict[str, Any]) -> None:
+        sess = event.get("flowise_session_id")
+        if not sess or not self._ws:
+            return
+        out = {
+            "type": "node_result",
+            "sessionId": sess,
+            "outputs": {
+                "diffs": event.get("diffs", []),
+                "tests": event.get("tests", []),
+            },
+            "metadata": {
+                "proposal_id": event.get("proposal_id"),
+                "event_type": event.get("event_type"),
+                "confidence": event.get("confidence"),
+                "timestamp": _utcnow(),
+            },
+        }
+        try:
+            await self._ws.send(json.dumps(out))
+        except Exception as e:
+            logger.warning("Flowise send failed: %s", e)

--- a/tests/runtime/test_gemini_codegen_ability.py
+++ b/tests/runtime/test_gemini_codegen_ability.py
@@ -1,0 +1,45 @@
+import pytest
+
+from src.abilities.gemini_codegen_ability import GeminiCodegenAbility
+
+
+class DummyBus:
+    def __init__(self) -> None:
+        self.events: list[dict] = []
+
+    async def emit(self, event: dict) -> None:
+        self.events.append(event)
+
+    async def subscribe(self, event_type: str, handler):
+        return None
+
+
+@pytest.mark.asyncio
+async def test_local_fallback_emits_proposal(monkeypatch):
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    ability = GeminiCodegenAbility()
+    await ability.setup(event_bus=DummyBus(), store=None, config={})
+    await ability.start()
+
+    out: dict = {}
+
+    async def capture(evt_type: str, **payload):
+        out["evt_type"] = evt_type
+        out["payload"] = payload
+
+    ability.emit_event = capture  # type: ignore
+
+    await ability._on_request(
+        {
+            "event_type": "codegen_request",
+            "requirements": "Create a FastAPI /users endpoint with JWT auth",
+            "repo_path": ".",
+            "context_files": [],
+        }
+    )
+
+    assert out["evt_type"] == "codegen_implementation_proposed"
+    payload = out["payload"]
+    assert isinstance(payload.get("proposal_id"), str)
+    assert payload.get("diffs")
+    assert payload.get("tests") is not None


### PR DESCRIPTION
## Summary
- add Gemini-driven `codegen_request` ability with local fallback
- bridge Dify and Flowise UI requests into `codegen_*` events
- cover ability fallback with unit test

## Testing
- `pre-commit run --all-files`
- `pytest tests/runtime -vv`


------
https://chatgpt.com/codex/tasks/task_e_68ab4e1d9fc08328acbb26a91902b834