### PR TITLE
feat(codeact): Add Python action space (CodeAct) with sandbox executor, loop, and EventBus integration

### DIFF
--- a/src/codeact/__init__.py
+++ b/src/codeact/__init__.py
@@ -1,0 +1,19 @@
+"""CodeAct - Python action space loop with sandboxed execution."""
+
+from .actions import AgentFinish, BrowseInteractive, CmdRun, FileEdit, IPythonRunCell
+from .runner import CodeActRunner
+from .sandbox import PythonSandbox, SandboxResult, SandboxError
+from .observation import Observation
+
+__all__ = [
+    "AgentFinish",
+    "BrowseInteractive",
+    "CmdRun",
+    "FileEdit",
+    "IPythonRunCell",
+    "CodeActRunner",
+    "PythonSandbox",
+    "SandboxResult",
+    "SandboxError",
+    "Observation",
+]

--- a/src/codeact/actions.py
+++ b/src/codeact/actions.py
@@ -1,0 +1,43 @@
+"""Action definitions for the CodeAct loop."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+
+@dataclass(slots=True)
+class CmdRun:
+    """Run a shell command."""
+
+    command: Iterable[str]
+
+
+@dataclass(slots=True)
+class IPythonRunCell:
+    """Execute a snippet of Python code."""
+
+    code: str
+
+
+@dataclass(slots=True)
+class FileEdit:
+    """Edit a file on disk."""
+
+    path: str
+    content: str
+
+
+@dataclass(slots=True)
+class BrowseInteractive:
+    """Placeholder for interactive browsing."""
+
+    url: str
+    query: str | None = None
+
+
+@dataclass(slots=True)
+class AgentFinish:
+    """Signal that the agent has finished."""
+
+    result: Any | None = None

--- a/src/codeact/bus_handlers.py
+++ b/src/codeact/bus_handlers.py
@@ -1,0 +1,67 @@
+"""EventBus handlers for CodeAct."""
+
+from __future__ import annotations
+
+import uuid
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from src.core.structures import generate_atom_id
+
+from .actions import IPythonRunCell
+from .observation import Observation
+from .runner import CodeActRunner
+
+logger = logging.getLogger(__name__)
+
+CODEACT_NAMESPACE = uuid.UUID("7c1f2a2e-73bd-4d3c-8e34-4f6e0c7e8c20")
+
+
+@dataclass(slots=True)
+class CodeActStartRequest:
+    code: str
+
+
+@dataclass(slots=True)
+class CodeActStepRequest:
+    code: str
+
+
+def _bond_id(src: str, bond_type: str, tgt: str) -> str:
+    seed = f"{src}|{bond_type}|{tgt}"
+    return str(uuid.uuid5(CODEACT_NAMESPACE, seed))
+
+
+async def _emit_observation(bus: Any, code: str, obs: Observation) -> None:
+    code_atom = {
+        "atom_id": generate_atom_id("CODE", "", code, CODEACT_NAMESPACE),
+        "atom_type": "CODE",
+        "content": code,
+    }
+    obs_atom = obs.to_atom(CODEACT_NAMESPACE)
+    await bus.emit({"event_type": "batch_atoms_created", "atoms": [code_atom, obs_atom]})
+    bond = {
+        "bond_id": _bond_id(code_atom["atom_id"], "OBSERVED", obs_atom["atom_id"]),
+        "source_id": code_atom["atom_id"],
+        "target_id": obs_atom["atom_id"],
+        "bond_type": "OBSERVED",
+    }
+    await bus.emit({"event_type": "batch_bonds_added", "bonds": [bond]})
+    await bus.emit({"event_type": "ui_notification", "message": obs_atom["content"]})
+
+
+async def handle_start(event: CodeActStartRequest, bus: Any, runner: CodeActRunner) -> Observation:
+    logger.debug("CodeAct start: %s", event.code)
+    initial = IPythonRunCell(code=event.code)
+    obs = await runner.run(initial)
+    await _emit_observation(bus, event.code, obs)
+    return obs
+
+
+async def handle_step(event: CodeActStepRequest, bus: Any, runner: CodeActRunner) -> Observation:
+    logger.debug("CodeAct step: %s", event.code)
+    action = IPythonRunCell(code=event.code)
+    obs = await runner.run(action)
+    await _emit_observation(bus, event.code, obs)
+    return obs

--- a/src/codeact/observation.py
+++ b/src/codeact/observation.py
@@ -1,0 +1,24 @@
+"""Observation utilities for CodeAct."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import uuid
+from typing import Any
+
+from src.core.structures import generate_atom_id
+
+
+@dataclass(slots=True)
+class Observation:
+    """Normalized output of sandbox execution."""
+
+    stdout: str = ""
+    stderr: str = ""
+    error: str | None = None
+
+    def to_atom(self, namespace: uuid.UUID) -> dict[str, Any]:
+        """Convert this observation into an atom dictionary."""
+        content = self.stdout or self.error or ""
+        atom_id = generate_atom_id("OBSERVATION", "", content, namespace)
+        return {"atom_id": atom_id, "atom_type": "OBSERVATION", "content": content}

--- a/src/codeact/runner.py
+++ b/src/codeact/runner.py
@@ -1,0 +1,43 @@
+"""Code-Execute-Observe loop for the CodeAct system."""
+
+from __future__ import annotations
+
+import logging
+from typing import Callable
+
+from .actions import AgentFinish, IPythonRunCell
+from .observation import Observation
+from .sandbox import PythonSandbox
+
+logger = logging.getLogger(__name__)
+
+
+class CodeActRunner:
+    """Simple loop executing actions and feeding observations to a policy."""
+
+    def __init__(self, sandbox: PythonSandbox, policy: Callable[[Observation], AgentFinish | IPythonRunCell]):
+        self.sandbox = sandbox
+        self.policy = policy
+
+    async def step(self, action: IPythonRunCell) -> Observation:
+        result = await self.sandbox.run(action.code)
+        obs = Observation(stdout=result.stdout, stderr=result.stderr, error=result.error)
+        self._track_resources(obs)
+        return obs
+
+    async def run(self, initial: IPythonRunCell, max_steps: int = 10) -> Observation:
+        action: AgentFinish | IPythonRunCell = initial
+        observation = Observation()
+        for _ in range(max_steps):
+            if isinstance(action, AgentFinish):
+                logger.debug("Agent finished early")
+                break
+            observation = await self.step(action)
+            action = self.policy(observation)
+            if isinstance(action, AgentFinish):
+                break
+        return observation
+
+    def _track_resources(self, observation: Observation) -> None:
+        """Placeholder for memory/energy accounting."""
+        logger.debug("Resource hook - stdout %d chars", len(observation.stdout))

--- a/src/codeact/sandbox.py
+++ b/src/codeact/sandbox.py
@@ -1,0 +1,110 @@
+"""Sandboxed Python execution for CodeAct."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import io
+import logging
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+logger = logging.getLogger(__name__)
+
+
+class SandboxError(Exception):
+    """Raised when execution violates sandbox constraints."""
+
+
+@dataclass(slots=True)
+class SandboxResult:
+    stdout: str
+    stderr: str
+    error: str | None
+    locals: dict[str, Any]
+
+
+class PythonSandbox:
+    """Execute Python code with basic safety guardrails."""
+
+    def __init__(
+        self,
+        allowed_imports: Iterable[str] | None = None,
+        timeout: float = 5.0,
+        stdout_limit: int = 10_000,
+        stderr_limit: int = 10_000,
+        workdir: str | None = None,
+    ) -> None:
+        self.allowed_imports = set(allowed_imports or {"math", "json", "csv", "statistics"})
+        self.timeout = timeout
+        self.stdout_limit = stdout_limit
+        self.stderr_limit = stderr_limit
+        self.workdir = workdir
+        self._globals = self._build_globals()
+
+    # ------------------------------------------------------------------
+    def _build_globals(self) -> dict[str, Any]:
+        allowed_builtins = {
+            "print": print,
+            "range": range,
+            "len": len,
+            "sum": sum,
+            "min": min,
+            "max": max,
+            "abs": abs,
+            "float": float,
+            "int": int,
+            "zip": zip,
+            "open": open,
+        }
+
+        def _import(name: str, globals: Any = None, locals: Any = None, fromlist: tuple[str, ...] = (), level: int = 0):
+            if name in self.allowed_imports:
+                return __import__(name, globals, locals, fromlist, level)
+            raise SandboxError(f"import of '{name}' is not allowed")
+
+        builtins: dict[str, Any] = dict(allowed_builtins)
+        builtins["__import__"] = _import
+        return {"__builtins__": builtins}
+
+    # ------------------------------------------------------------------
+    async def run(self, code: str) -> SandboxResult:
+        """Execute code asynchronously with timeouts and IO capture."""
+
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        globals_ns: dict[str, Any] = dict(self._globals)
+
+        def _execute() -> SandboxResult:
+            try:
+                with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+                    exec(compile(code, "<sandbox>", "exec"), globals_ns, globals_ns)
+                return SandboxResult(
+                    stdout.getvalue()[-self.stdout_limit :],
+                    stderr.getvalue()[-self.stderr_limit :],
+                    None,
+                    {k: v for k, v in globals_ns.items() if k != "__builtins__"},
+                )
+            except Exception as exc:  # noqa: BLE001 - capture for observation
+                return SandboxResult(
+                    stdout.getvalue()[-self.stdout_limit :],
+                    stderr.getvalue()[-self.stderr_limit :],
+                    repr(exc),
+                    {k: v for k, v in globals_ns.items() if k != "__builtins__"},
+                )
+
+        try:
+            if self.workdir:
+                import os
+
+                cwd = os.getcwd()
+                os.makedirs(self.workdir, exist_ok=True)
+                os.chdir(self.workdir)
+                try:
+                    return await asyncio.wait_for(asyncio.to_thread(_execute), self.timeout)
+                finally:
+                    os.chdir(cwd)
+            return await asyncio.wait_for(asyncio.to_thread(_execute), self.timeout)
+        except asyncio.TimeoutError:
+            logger.warning("Sandbox execution timed out")
+            return SandboxResult("", "", "timeout", {})

--- a/src/codeact/tests/test_idempotency_finish.py
+++ b/src/codeact/tests/test_idempotency_finish.py
@@ -1,0 +1,31 @@
+import pytest
+from hypothesis import given, strategies as st
+
+from codeact.actions import AgentFinish
+from codeact.bus_handlers import CodeActStartRequest, handle_start
+from codeact.runner import CodeActRunner
+from codeact.sandbox import PythonSandbox
+from tests.runtime.fakes import FakeEventBus
+
+
+class FinishPolicy:
+    def __call__(self, _):
+        return AgentFinish()
+
+
+@given(st.text(min_size=1, max_size=20))
+@pytest.mark.asyncio
+async def test_idempotent_atoms(code):
+    sandbox = PythonSandbox()
+    runner = CodeActRunner(sandbox, FinishPolicy())
+    bus = FakeEventBus()
+    event = CodeActStartRequest(code=code)
+    await handle_start(event, bus, runner)
+    first_atoms = [e for e in bus.events if e["event_type"] == "batch_atoms_created"][0]["atoms"]
+    first_bonds = [e for e in bus.events if e["event_type"] == "batch_bonds_added"][0]["bonds"]
+    bus.events.clear()
+    await handle_start(event, bus, runner)
+    second_atoms = [e for e in bus.events if e["event_type"] == "batch_atoms_created"][0]["atoms"]
+    second_bonds = [e for e in bus.events if e["event_type"] == "batch_bonds_added"][0]["bonds"]
+    assert first_atoms == second_atoms
+    assert first_bonds == second_bonds

--- a/src/codeact/tests/test_loop_sales_linear_regression.py
+++ b/src/codeact/tests/test_loop_sales_linear_regression.py
@@ -1,0 +1,45 @@
+import textwrap
+
+import pytest
+
+from codeact.actions import AgentFinish
+from codeact.bus_handlers import CodeActStartRequest, handle_start
+from codeact.runner import CodeActRunner
+from codeact.sandbox import PythonSandbox
+from tests.runtime.fakes import FakeEventBus
+
+
+class FinishPolicy:
+    def __call__(self, _):
+        return AgentFinish()
+
+
+@pytest.mark.asyncio
+async def test_sales_regression(tmp_path):
+    data = "ads,sales\n1,3\n2,5\n3,7\n"
+    (tmp_path / "sales.csv").write_text(data)
+    code = textwrap.dedent(
+        """
+        import csv, statistics
+        xs, ys = [], []
+        with open('sales.csv') as f:
+            for row in csv.DictReader(f):
+                xs.append(float(row['ads']))
+                ys.append(float(row['sales']))
+        n = len(xs)
+        x_mean = sum(xs) / n
+        y_mean = sum(ys) / n
+        num = sum((x - x_mean)*(y - y_mean) for x, y in zip(xs, ys))
+        den = sum((x - x_mean)**2 for x in xs)
+        m = num / den
+        b = y_mean - m * x_mean
+        print(f'y={m:.1f}x+{b:.1f}')
+        """
+    ).strip()
+    sandbox = PythonSandbox(workdir=str(tmp_path))
+    runner = CodeActRunner(sandbox, FinishPolicy())
+    bus = FakeEventBus()
+    event = CodeActStartRequest(code=code)
+    await handle_start(event, bus, runner)
+    ui_event = [e for e in bus.events if e["event_type"] == "ui_notification"][0]
+    assert "y=2.0x+1.0" in ui_event["message"]

--- a/src/codeact/tests/test_sandbox_basic.py
+++ b/src/codeact/tests/test_sandbox_basic.py
@@ -1,0 +1,18 @@
+import pytest
+
+from codeact.sandbox import PythonSandbox
+
+
+@pytest.mark.asyncio
+async def test_exec_basic():
+    sb = PythonSandbox()
+    result = await sb.run("print('hi')")
+    assert result.stdout.strip() == "hi"
+    assert result.error is None
+
+
+@pytest.mark.asyncio
+async def test_disallow_import():
+    sb = PythonSandbox()
+    result = await sb.run("import os")
+    assert "not allowed" in (result.error or "")


### PR DESCRIPTION
## Summary
- introduce CodeAct module with sandboxed Python executor and iterative runner
- wire CodeAct to EventBus emitting atoms, bonds, and UI notification events
- cover sandbox, regression loop, and idempotency with focused tests

## Changes
- add actions, sandbox, runner, bus handlers, and observation helpers under `src/codeact`
- support deterministic UUIDv5 for atoms, bonds, and observations
- implement tests verifying sandbox safety, sales regression example, and event idempotency

## Verification
- `pre-commit run --all-files`
- `pytest tests/runtime src/codeact/tests`

## Runtime impact
- sandbox execution introduces minor (<5s) timeout-managed overhead per CodeAct step

## Observability
- emits `batch_atoms_created`, `batch_bonds_added`, and `ui_notification` events for UI and knowledge graph consumption

## Rollback
- revert this PR

------
https://chatgpt.com/codex/tasks/task_e_68ab6ce9d4a08328a0a2de7dda1da1af