### PR TITLE
[runtime] add user input tool

### DIFF
--- a/reug/services.py
+++ b/reug/services.py
@@ -26,7 +26,8 @@ from .events import EventEmitter, hash_json, new_span_id
 
 ENFORCE_SCHEMA = os.getenv("REUG_SCHEMA_ENFORCE", "true").lower() == "true"
 
-StepKind = Literal["SEARCH","COMPUTE","ANALYZE","GENERATE","VALIDATE"]
+# Include USER to allow tools that capture human input during execution.
+StepKind = Literal["SEARCH", "COMPUTE", "ANALYZE", "GENERATE", "VALIDATE", "USER"]
 
 @dataclass
 class PlanStep:
@@ -72,6 +73,10 @@ class _FallbackExecutor:
     """Extremely simple safe-ish executor for COMPUTE/ANALYZE/GENERATE kinds (tests only)."""
     def run(self, tool_id: str, args: Dict[str, Any], timeout_s: float = 5.0) -> Dict[str, Any]:
         kind = args.get("_kind", "COMPUTE")
+        if tool_id == "tool.user_input":
+            prompt = args.get("prompt", "")
+            # Use built-in input to simulate a live user response.
+            return {"response": input(prompt)}
         if kind in ("COMPUTE","ANALYZE"):
             expr = args.get("expr") or args.get("code") or "None"
             # Very limited eval (no imports), only numeric/simple expressions
@@ -90,11 +95,12 @@ def default_tool_resolver(step: PlanStep, _ctx: Dict[str, Any]) -> Tuple[str, Di
     Real systems can consult a registry by capability + schema.
     """
     tool_map = {
-        "SEARCH":  "tool.search.basic",
+        "SEARCH": "tool.search.basic",
         "COMPUTE": "tool.compute.python",
         "ANALYZE": "tool.analyze.basic",
-        "GENERATE":"tool.generate.text",
-        "VALIDATE":"tool.validate.schema",
+        "GENERATE": "tool.generate.text",
+        "VALIDATE": "tool.validate.schema",
+        "USER": "tool.user_input",
     }
     return tool_map.get(step.kind, f"tool.{step.kind.lower()}.generic"), step.args
 

--- a/tests/runtime/test_user_input_tool.py
+++ b/tests/runtime/test_user_input_tool.py
@@ -1,0 +1,34 @@
+import asyncio
+
+from reug.events import EventEmitter
+from reug.fsm import ExecutionFlow
+from reug.services import create_services
+
+
+def test_user_input_tool(monkeypatch):
+    """Ensure the fallback executor can capture live user input."""
+    events: list[dict] = []
+    emitter = EventEmitter(sink=lambda e: events.append(e))
+    services = create_services(emitter)
+    flow = ExecutionFlow(services, emitter)
+
+    monkeypatch.setattr("builtins.input", lambda prompt="": "hello")
+
+    ctx = asyncio.run(
+        flow.run(
+            {
+                "plan": [
+                    {
+                        "id": "s1",
+                        "kind": "USER",
+                        "args": {"prompt": "say something:"},
+                    }
+                ]
+            }
+        )
+    )
+
+    assert ctx.results[0]["response"] == "hello"
+    tool_ok = [e for e in events if e.get("event_type") == "TOOL_CALL_OK"]
+    assert tool_ok and tool_ok[0]["payload"]["tool_id"] == "tool.user_input"
+


### PR DESCRIPTION
## Summary
- allow agent to request live user input via `tool.user_input`

## Changes
- extend StepKind and resolver for `USER` steps
- handle `tool.user_input` in fallback executor
- add test for user input tool

## Verification
- `make deps`
- `pre-commit run --all-files`
- `PYTHONPATH=./src pytest -q tests/runtime`
- `make run` + `curl http://localhost:8080/healthz`

## Runtime impact
- new tool only runs when invoked; negligible overhead otherwise

## Observability
- emits standard `TOOL_CALL_*` events

## Rollback
- revert commit `3c47def`

------
https://chatgpt.com/codex/tasks/task_e_68ab831a02048328b81af40b045e8c1f