### PR TITLE
[runtime] Add client disconnect test

### DIFF
--- a/tests/runtime/test_router_disconnect.py
+++ b/tests/runtime/test_router_disconnect.py
@@ -1,4 +1,10 @@
+
+import asyncio
+import socket
+
+import httpx
 import pytest
+import uvicorn
 from fastapi import FastAPI
 from reug_runtime.router import router
 
@@ -15,6 +21,32 @@ def _mk_app():
     return app
 
 
-@pytest.mark.skip("client disconnect simulation not supported in test environment")
-def test_client_disconnect(monkeypatch):
-    pass
+@pytest.mark.asyncio
+async def test_client_disconnect():
+    app = _mk_app()
+    sock = socket.socket()
+    sock.bind(("127.0.0.1", 0))
+    host, port = sock.getsockname()
+    sock.close()
+
+    config = uvicorn.Config(app, host=host, port=port, log_level="error")
+    server = uvicorn.Server(config)
+    server_task = asyncio.create_task(server.serve())
+    try:
+        while not server.started:
+            await asyncio.sleep(0.01)
+        async with httpx.AsyncClient(base_url=f"http://{host}:{port}") as client:
+            async with client.stream(
+                "POST", "/v1/chat/stream", json={"message": "hi", "session_id": "s1"}
+            ) as resp:
+                chunk_iter = resp.aiter_text()
+                first_chunk = await chunk_iter.__anext__()
+                assert first_chunk
+                await resp.aclose()
+        await asyncio.sleep(0.1)
+    finally:
+        server.should_exit = True
+        await server_task
+    events = app.state.event_bus.events
+    assert {"type": "TaskFailed", "reason": "client_disconnected"} in events
+    assert not any(e["type"] == "TaskSucceeded" for e in events)


### PR DESCRIPTION
## Summary
- cover router behaviour when a streaming client disconnects

## Changes
- add test_client_disconnect using a temporary uvicorn server that aborts mid-stream and asserts TaskFailed{reason:"client_disconnected"}

## Verification
- `pre-commit run --all-files`
- `pytest tests/runtime`

## Runtime impact
- none, test-only change

## Observability
- confirms TaskFailed telemetry on client disconnect

## Rollback
- revert this commit

------
https://chatgpt.com/codex/tasks/task_e_68ab95a107e883288f988771a208ab00