### PR TITLE
telemetry: send MCP events

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,9 @@ REUG_SCHEMA_ENFORCE=true
 # ===== Persistence & Logging =====
 REUG_EVENT_LOG_DIR=./logs/events
 REUG_TOOL_REGISTRY_DIR=./tools_registry
+# MCP telemetry endpoint (optional)
+MCP_BROADCAST_URL=
+MCP_BROADCAST_TOKEN=
 
 # ===== LLM Provider (choose one) =====
 # OPENAI_API_KEY=sk-your-key-here

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -11,6 +11,8 @@
    - `REUG_EVENT_LOG_DIR` (default `./logs/events`)
    - `REUG_TOOL_REGISTRY_DIR`
    - `REUG_MAX_TOOL_CALLS`, `REUG_EXEC_TIMEOUT_S`, `REUG_EXEC_MAX_RETRIES`
+   - `MCP_BROADCAST_URL` (optional MCP telemetry endpoint)
+   - `MCP_BROADCAST_TOKEN` (bearer token for MCP_BROADCAST_URL)
 
    If `REUG_EVENTBUS` is unset or a Redis backend is unavailable, the runtime
    gracefully falls back to appending JSONL telemetry under

--- a/tests/runtime/test_mcp_broadcaster.py
+++ b/tests/runtime/test_mcp_broadcaster.py
@@ -1,0 +1,29 @@
+import json
+import httpx
+import pytest
+
+from src.telemetry.mcp_broadcaster import MCPTelemetryBroadcaster
+
+
+@pytest.mark.asyncio
+async def test_broadcaster_posts_events(monkeypatch):
+    received: list[dict[str, object]] = []
+    auth_headers: list[str | None] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        received.append(json.loads(request.content.decode()))
+        auth_headers.append(request.headers.get("Authorization"))
+        return httpx.Response(200)
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as client:
+        monkeypatch.setenv("MCP_BROADCAST_URL", "https://mcp.test/telemetry")
+        monkeypatch.setenv("MCP_BROADCAST_TOKEN", "testtoken")
+        broadcaster = MCPTelemetryBroadcaster(http_client=client)
+        await broadcaster.start()
+        await broadcaster.broadcast_event("tool_call", "unit_test", {"foo": "bar"})
+        await broadcaster.stop()
+
+    tool_events = [e for e in received if e["event_type"] == "tool_call"]
+    assert tool_events and tool_events[0]["data"] == {"foo": "bar"}
+    assert any(h == "Bearer testtoken" for h in auth_headers)


### PR DESCRIPTION
## Summary
- implement async http client posting telemetry to MCP server
- document MCP_BROADCAST_URL and MCP_BROADCAST_TOKEN env vars
- test MCP broadcaster sends payloads to mocked endpoint

## Testing
- `pre-commit run --all-files`
- `pytest tests/runtime`


------
https://chatgpt.com/codex/tasks/task_e_68ab95a2a44c8328a363a31b0029a9e4