### PR TITLE
runtime: add BlockParser tests

### DIFF
--- a/tests/runtime/test_block_parser.py
+++ b/tests/runtime/test_block_parser.py
@@ -1,0 +1,33 @@
+from reug_runtime.router import BlockParser, MAX_BUFFER_BYTES
+
+
+def test_partial_tags():
+    parser = BlockParser()
+    parser.feed('<tool_call>{"tool":"echo",')
+    assert parser.get_tool_call() is None
+    parser.feed('"args":{}}</tool_call>')
+    assert parser.get_tool_call() == {"tool": "echo", "args": {}}
+
+
+def test_extract_malformed_json_and_recovery():
+    parser = BlockParser()
+    parser.feed('<tool_call>{bad}</tool_call>')
+    assert parser._extract('tool_call') is None
+    parser.feed('<tool_call>{"tool":"ok","args":{}}</tool_call>')
+    assert parser.get_tool_call() == {"tool": "ok", "args": {}}
+
+
+def test_feed_truncates_buffer_on_overflow():
+    parser = BlockParser()
+    parser.feed('x' * (MAX_BUFFER_BYTES + 10))
+    assert len(parser.buffer) == MAX_BUFFER_BYTES
+    tag = '<final_answer>{"content":"ok"}</final_answer>'
+    parser.feed(tag)
+    assert parser.buffer.endswith(tag)
+    assert parser.get_final_answer() == {"content": "ok"}
+
+
+def test_final_answer_fallback_on_invalid_json():
+    parser = BlockParser()
+    parser.feed('<final_answer>{not:json}</final_answer>')
+    assert parser.get_final_answer() == {"content": "{not:json}"}


### PR DESCRIPTION
## Summary
- add BlockParser tests covering partial tag streaming, malformed JSON handling, buffer cap, and final-answer fallback

## Changes
- add tests/runtime/test_block_parser.py exercising BlockParser.feed, _extract, get_tool_call, and get_final_answer

## Verification
- `pre-commit run --all-files`
- `pytest -q tests/runtime`

## Runtime impact
- none

## Observability
- no changes

## Rollback
- revert this PR


------
https://chatgpt.com/codex/tasks/task_e_68aba51d9ab88328bed9673738693a35