### PR TITLE
[runtime] Add router tool tests

### DIFF
--- a/tests/runtime/test_router_tools_git_patch.py
+++ b/tests/runtime/test_router_tools_git_patch.py
@@ -1,0 +1,42 @@
+import os
+import subprocess
+
+import pytest
+
+from reug_runtime.router_tools import git_apply_patch
+
+
+@pytest.mark.asyncio
+async def test_git_apply_patch(tmp_path):
+    repo = tmp_path
+    subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "a@b.c"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "Tester"], cwd=repo, check=True)
+    file_path = repo / "file.txt"
+    file_path.write_text("hello\n")
+    subprocess.run(["git", "add", "file.txt"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=repo, check=True, capture_output=True)
+    file_path.write_text("hello\nworld\n")
+    patch = subprocess.run(
+        ["git", "diff", "file.txt"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    file_path.write_text("hello\n")
+    cwd = os.getcwd()
+    os.chdir(repo)
+    try:
+        result = await git_apply_patch({"patch": patch})
+    finally:
+        os.chdir(cwd)
+    assert result["ok"], result
+    assert file_path.read_text() == "hello\nworld\n"
+    os.chdir(repo)
+    try:
+        result_fail = await git_apply_patch({"patch": patch})
+    finally:
+        os.chdir(cwd)
+    assert not result_fail["ok"]
+    assert result_fail["stderr"]

--- a/tests/runtime/test_router_tools_io.py
+++ b/tests/runtime/test_router_tools_io.py
@@ -1,0 +1,21 @@
+import pytest
+from fastapi import HTTPException
+from reug_runtime.router_tools import fs_read, fs_write
+
+
+@pytest.mark.asyncio
+async def test_fs_write_and_read_roundtrip(tmp_path):
+    file_path = tmp_path / "sample.txt"
+    content = "hello there"
+    write_result = await fs_write({"path": str(file_path), "content": content})
+    assert write_result == {"ok": True}
+    read_result = await fs_read({"path": str(file_path)})
+    assert read_result == {"content": content}
+
+
+@pytest.mark.asyncio
+async def test_fs_read_missing_file(tmp_path):
+    missing = tmp_path / "missing.txt"
+    with pytest.raises(HTTPException) as excinfo:
+        await fs_read({"path": str(missing)})
+    assert excinfo.value.status_code == 404

--- a/tests/runtime/test_router_tools_pytest_run.py
+++ b/tests/runtime/test_router_tools_pytest_run.py
@@ -1,0 +1,25 @@
+import pytest
+
+from reug_runtime.router_tools import pytest_run
+
+
+@pytest.mark.asyncio
+async def test_pytest_run_success(tmp_path):
+    test_file = tmp_path / "test_sample.py"
+    test_file.write_text("def test_ok():\n    assert 1 == 1\n")
+    result = await pytest_run({"target": str(test_file)})
+    assert result["ok"]
+    assert result["exit_code"] == 0
+    assert "1 passed" in result["stdout"]
+    assert result["stderr"] == ""
+
+
+@pytest.mark.asyncio
+async def test_pytest_run_failure(tmp_path):
+    test_file = tmp_path / "test_fail.py"
+    test_file.write_text("def test_fail():\n    assert False\n")
+    result = await pytest_run({"target": str(test_file)})
+    assert not result["ok"]
+    assert result["exit_code"] != 0
+    combined = result["stdout"] + result["stderr"]
+    assert "1 failed" in combined


### PR DESCRIPTION
## Summary
- add tests for fs_read/fs_write file operations
- exercise git_apply_patch on success and failure
- ensure pytest_run reports exit codes and streams

## Changes
- new runtime tests covering fs_read/fs_write
- git_apply_patch test verifies patch application and error reporting
- pytest_run test checks stdout/stderr and exit codes

## Verification
- `pre-commit run --all-files`
- `pytest tests/runtime`

## Runtime impact
- none, tests only

## Observability
- no changes

## Rollback
- revert this PR


------
https://chatgpt.com/codex/tasks/task_e_68aba51bb9b88328aaf47a92e26f03a0