### PR TITLE
[runtime] preserve early final answers

### DIFF
--- a/src/reug_runtime/router.py
+++ b/src/reug_runtime/router.py
@@ -496,7 +496,6 @@ Protocol:
                             }
                         )
                         used_spans.append({"span_id": span, "tool": tool_name})
-                        parser.reset()
                         tool_calls += 1
                         break  # tool execution done for this cycle
                     except TimeoutError:

--- a/tests/runtime/test_execute_turn_stream.py
+++ b/tests/runtime/test_execute_turn_stream.py
@@ -1,0 +1,76 @@
+import pytest
+
+from reug_runtime.router import execute_turn
+from tests.runtime.fakes import (
+    FakeAbilityRegistry,
+    FakeEventBus,
+    FakeKG,
+    FakeLLM,
+)
+
+
+@pytest.mark.asyncio
+async def test_execute_turn_stream_normal_flow() -> None:
+    bus = FakeEventBus()
+    reg = FakeAbilityRegistry()
+    kg = FakeKG()
+    model = FakeLLM()
+
+    gen = execute_turn("hi", "s1", bus, reg, kg, model)
+    chunks: list[str] = []
+    async for chunk in gen:
+        chunks.append(chunk)
+
+    output = "".join(chunks)
+    assert "<tool_call>" in output
+    assert output.endswith("</final_answer>")
+
+    event_types = [e["type"] for e in bus.events]
+    assert event_types.index("AbilityCalled") < event_types.index("AbilitySucceeded") < event_types.index(
+        "TaskSucceeded"
+    )
+
+    with pytest.raises(StopAsyncIteration):
+        await gen.__anext__()
+
+
+class _EarlyFinalLLM:
+    """LLM that emits tool call and final answer in one stream."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def stream_chat(self, messages, timeout):  # type: ignore[override]
+        self.calls += 1
+        if self.calls == 1:
+            text = (
+                '<tool_call>{"tool":"echo","args":{"payload":"hi"}}</tool_call>'
+                '<final_answer>{"content":"early done","citations":[]}</final_answer>'
+            )
+            yield {"content": text}
+        else:
+            if False:
+                yield {"content": ""}  # pragma: no cover
+
+
+@pytest.mark.asyncio
+async def test_execute_turn_stream_early_final_answer() -> None:
+    bus = FakeEventBus()
+    reg = FakeAbilityRegistry()
+    kg = FakeKG()
+    model = _EarlyFinalLLM()
+
+    gen = execute_turn("hi", "s1", bus, reg, kg, model)
+    chunks = [chunk async for chunk in gen]
+
+    output = "".join(chunks)
+    assert output.endswith("</final_answer>")
+    assert model.calls == 1
+
+    event_types = [e["type"] for e in bus.events]
+    assert event_types.index("AbilityCalled") < event_types.index("AbilitySucceeded") < event_types.index(
+        "TaskSucceeded"
+    )
+
+    with pytest.raises(StopAsyncIteration):
+        await gen.__anext__()


### PR DESCRIPTION
## Summary
- add tests for execute_turn stream covering normal and early final answer cases
- keep parser buffer to handle early final answers without extra model call

## Changes
- add `tests/runtime/test_execute_turn_stream.py`
- adjust router to avoid resetting parser after successful tool calls

## Verification
- `pre-commit run --all-files`
- `pytest -q tests/runtime`

## Runtime impact
- avoids an extra model invocation when `<final_answer>` is emitted with a tool call

## Observability
- no new event types or fields

## Rollback
- revert this commit

------
https://chatgpt.com/codex/tasks/task_e_68aba520099c8328bab7cb65ff104c68