### PR TITLE
[build] Silence dependency install and drop CUDA extras

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ help: ## Show this help
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
 deps: ## Install runtime + test deps
-	pip install -r requirements.txt -r requirements-test.txt
+	pip install -q -r requirements.txt -r requirements-test.txt
 
 run: ## Start FastAPI dev server on :8080
 	uvicorn app:app --reload --port 8080

--- a/cortex/pyproject.toml
+++ b/cortex/pyproject.toml
@@ -29,8 +29,9 @@ dev = [
     "pre-commit"
 ]
 
-gpu = [
-    "torch",
-    "transformers",
-    "accelerate"
-]
+# gpu extras disabled for non-CUDA environments
+# gpu = [
+#     "torch",
+#     "transformers",
+#     "accelerate"
+# ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,8 @@
+# GPU-related packages (commented out; NVIDIA CUDA not available)
+# torch
+# nvidia-cuda-runtime-cu12
+# nvidia-cudnn-cu12
+
 # Core dependencies
 pydantic>=2.11
 protobuf>=4.0


### PR DESCRIPTION
## Summary
- quiet dependency installation for faster setup
- disable unused GPU/CUDA extras

## Changes
- add `-q` flag to `make deps`
- comment out CUDA packages in requirements
- comment out GPU extras in `cortex/pyproject.toml`

## Verification
- `make deps`
- `pre-commit run --all-files`
- `pytest -q tests/runtime`
- `python -m src.main --host 127.0.0.1 --port 9000`

## Runtime impact
- no runtime behavior change

## Observability
- no changes

## Rollback
- revert commit `8e0c609`


------
https://chatgpt.com/codex/tasks/task_e_68abb5110a8883288d53ffdf49d29d81