### PR TITLE
docs: separate GPU requirements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ This file gives coding agents *mechanical instructions*: build, test, style, and
 - Install deps:
   ```bash
   uv pip install -r requirements.txt -c constraints.txt
+  # add GPU support: uv pip install -r requirements-gpu.txt -c constraints.txt
   ```
 - Start runtime server:
   ```bash

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -28,6 +28,7 @@
 
    ```bash
    make deps               # pip install -r requirements.txt -r requirements-test.txt
+   # add GPU support: pip install -r requirements-gpu.txt
    make lint               # run pre-commit hooks
    make test-smoke         # quick runtime smoke test
    make run                # uvicorn app:app --reload --port 8080
@@ -70,6 +71,7 @@ Steps:
    - create .env from .env.example if missing; ensure PYTHONPATH=./src is set.
    - append GEMINI_API_KEY or OPENAI_API_KEY or ANTHROPIC_API_KEY if present.
    - install deps: pip install -r requirements.txt -r requirements-test.txt
+     # add GPU support: pip install -r requirements-gpu.txt
    - run pre-commit on touched files.
 2) Sanity checks
    - python -m pip show fastapi uvicorn

--- a/docs/self-insight-setup-enhanced.md
+++ b/docs/self-insight-setup-enhanced.md
@@ -29,9 +29,12 @@ Super Alita is a production-ready autonomous agent system with comprehensive sel
 git clone <repository>
 cd super-alita
 
-# Install dependencies
+# Install dependencies (CPU-only)
 pip install -r requirements.txt
 pip install -r requirements-test.txt
+
+# Add GPU acceleration
+# pip install -r requirements-gpu.txt
 
 # Verify environment
 python final_integration.py

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -3,7 +3,8 @@
 ## With pytest (recommended)
 
 ```
-pip install -r requirements.txt
+pip install -r requirements.txt         # CPU-only
+# pip install -r requirements-gpu.txt    # add GPU support
 pip install hypothesis   # optional
 PYTHONPATH=src pytest -q
 ```

--- a/requirements-gpu.txt
+++ b/requirements-gpu.txt
@@ -1,0 +1,6 @@
+-r requirements.txt
+
+# GPU dependencies
+torch
+nvidia-cuda-runtime-cu12
+nvidia-cudnn-cu12

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,3 @@
-# GPU-related packages (commented out; NVIDIA CUDA not available)
-# torch
-# nvidia-cuda-runtime-cu12
-# nvidia-cudnn-cu12
-
 # Core dependencies
 pydantic>=2.11
 protobuf>=4.0


### PR DESCRIPTION
## Summary
- isolate CUDA-related packages into a dedicated `requirements-gpu.txt`
- document CPU vs GPU installation paths in contributor and user docs

## Changes
- drop commented CUDA packages from `requirements.txt`
- add `requirements-gpu.txt` with `torch`, `nvidia-cuda-runtime-cu12`, and `nvidia-cudnn-cu12`
- mention optional GPU install in `AGENTS.md` and docs (`runtime`, `testing`, `self-insight-setup-enhanced`)

## Verification
- `make deps`
- `pre-commit run --all-files`
- `pytest tests/runtime`

## Runtime impact
- none; dependency management only

## Observability
- no telemetry changes

## Rollback
- revert commit `docs: separate GPU requirements`

------
https://chatgpt.com/codex/tasks/task_e_68abbc30710c8328af22cd1259de7f6b