### PR TITLE
[runtime] async event bus refactor

### DIFF
--- a/src/reug_runtime/event_bus.py
+++ b/src/reug_runtime/event_bus.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+"""Async event bus implementations for the REUG runtime."""
+
+import asyncio
+import json
+import logging
+import os
+import time
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Any
+
+
+logger = logging.getLogger(__name__)
+
+
+class BaseEventBus(ABC):
+    """Minimal interface for event bus implementations."""
+
+    @abstractmethod
+    async def emit(self, event: dict[str, Any]) -> dict[str, Any]:
+        """Emit an event and return the enriched payload."""
+
+
+class FileEventBus(BaseEventBus):
+    """Append events to a JSONL file asynchronously."""
+
+    def __init__(self, log_dir: str | None):
+        self.log_dir = Path(log_dir or "./logs/events")
+        self.log_dir.mkdir(parents=True, exist_ok=True)
+        self.file = self.log_dir / "events.jsonl"
+
+    async def emit(self, event: dict[str, Any]) -> dict[str, Any]:
+        event = {**event, "timestamp": time.time()}
+
+        def _write() -> None:
+            self.file.parent.mkdir(parents=True, exist_ok=True)
+            with self.file.open("a", encoding="utf-8") as f:
+                f.write(json.dumps(event, ensure_ascii=False) + "\n")
+
+        try:
+            await asyncio.to_thread(_write)
+        except Exception:
+            logger.exception("failed to write event", extra={"event": event})
+        return event
+
+
+class RedisEventBus(BaseEventBus):
+    """Publish events to a Redis channel asynchronously."""
+
+    def __init__(self, url: str = "redis://localhost:6379/0", channel: str = "reug-events"):
+        import redis  # type: ignore
+
+        self._r = redis.Redis.from_url(url)
+        self._ch = channel
+
+    async def emit(self, event: dict[str, Any]) -> dict[str, Any]:
+        event = {**event, "timestamp": time.time()}
+        try:
+            await asyncio.to_thread(self._r.publish, self._ch, json.dumps(event))
+        except Exception:
+            logger.exception("failed to publish event", extra={"event": event})
+        return event
+
+
+def make_event_bus() -> BaseEventBus:
+    """Factory selecting File or Redis bus based on environment."""
+
+    backend = os.getenv("REUG_EVENTBUS", "").strip().lower()
+    if backend == "redis":
+        url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+        channel = os.getenv("REUG_REDIS_CHANNEL", "reug-events")
+        try:
+            return RedisEventBus(url=url, channel=channel)
+        except Exception as e:  # pragma: no cover
+            logger.warning(
+                "Redis event bus unavailable (%s); falling back to file", e,
+                extra={"error": str(e)},
+            )
+    return FileEventBus(os.getenv("REUG_EVENT_LOG_DIR"))

--- a/tests/runtime/test_event_bus.py
+++ b/tests/runtime/test_event_bus.py
@@ -1,0 +1,47 @@
+import json
+
+import pytest
+
+from reug_runtime.event_bus import FileEventBus, RedisEventBus
+
+
+@pytest.mark.asyncio
+async def test_file_event_bus_writes(tmp_path):
+    bus = FileEventBus(str(tmp_path))
+    event = {"event_type": "PING"}
+    await bus.emit(event)
+
+    log = tmp_path / "events.jsonl"
+    assert log.exists()
+    data = json.loads(log.read_text().strip())
+    assert data["event_type"] == "PING"
+    assert "timestamp" in data
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration_redis()
+async def test_redis_event_bus_publishes():
+    import redis
+
+    try:
+        client = redis.Redis(host="127.0.0.1", port=6379, decode_responses=True)
+        client.ping()
+    except Exception:
+        pytest.skip("Redis server not available")
+
+    channel = "test.reug_runtime.events"
+    pubsub = client.pubsub()
+    pubsub.subscribe(channel)
+    pubsub.get_message(timeout=0.1)
+
+    bus = RedisEventBus(url="redis://127.0.0.1:6379/0", channel=channel)
+    await bus.emit({"event_type": "PING"})
+
+    message = None
+    for _ in range(10):
+        message = pubsub.get_message(timeout=1.0)
+        if message and message.get("type") == "message":
+            break
+    assert message is not None
+    data = json.loads(message["data"])
+    assert data["event_type"] == "PING"

--- a/tests/runtime/test_main_app.py
+++ b/tests/runtime/test_main_app.py
@@ -2,7 +2,8 @@
 
 from fastapi.testclient import TestClient
 
-from src.main import FileEventBus, create_app
+from reug_runtime.event_bus import FileEventBus
+from src.main import create_app
 
 
 def test_create_app_smoke(tmp_path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- switch event bus to async implementations and move to dedicated module

## Changes
- add `BaseEventBus` with file/redis backends using `asyncio.to_thread`
- import event bus factory in `create_app` to choose backend via `REUG_EVENTBUS`
- add unit tests for file and Redis event paths

## Verification
- `pre-commit run --all-files`
- `pytest tests/runtime`

## Runtime impact
- non-blocking event emission reduces I/O latency

## Observability
- structured logging for event bus errors

## Rollback
- revert this PR

------
https://chatgpt.com/codex/tasks/task_e_68abc397a66483289fb279e16207e2f8