### PR TITLE
[runtime] Add streaming LLM clients

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import os
 import sys
-from collections.abc import AsyncGenerator
 from pathlib import Path
 from typing import Any
 
@@ -164,52 +163,7 @@ class SimpleKG:
         )
 
 
-# --- LLM client: choose provider by available key (Gemini > OpenAI > Claude) ---
-class LLMClient:
-    def __init__(self):
-        self._provider = None
-        self._model = None
-
-        gemini = os.getenv("GEMINI_API_KEY")
-        openai_key = os.getenv("OPENAI_API_KEY")
-        anthropic = os.getenv("ANTHROPIC_API_KEY")
-
-        if gemini:
-            self._provider = "gemini"
-            # lazy import; replace with your client if desired
-            from collections.abc import AsyncGenerator as _T  # noqa: F401
-
-        elif openai_key:
-            self._provider = "openai"
-
-        elif anthropic:
-            self._provider = "anthropic"
-
-        else:
-            self._provider = "mock"  # dev fallback
-
-    async def stream_chat(
-        self, messages: list[dict[str, str]], timeout: float
-    ) -> AsyncGenerator[dict[str, str], None]:
-        """
-        IMPORTANT: This *must* yield {"content": "..."} chunks.
-        The REUG streaming router will parse <tool_call> / <tool_result> / <final_answer>.
-        """
-        # Minimal development behavior:
-        # If no tool_result yet, ask for an echo tool call; otherwise finalize.
-        has_result = any(
-            m["role"] == "assistant" and "<tool_result" in m["content"]
-            for m in messages
-        )
-        if not has_result:
-            yield {"content": "Thinking... "}
-            yield {
-                "content": '<tool_call>{"tool":"echo","args":{"payload":"hello"}}</tool_call>'
-            }
-        else:
-            yield {
-                "content": '<final_answer>{"content":"done: hello","citations":[]}</final_answer>'
-            }
+from reug_runtime.llm_client import get_llm_client
 
 
 # --- FastAPI factory ---
@@ -239,7 +193,7 @@ def create_app() -> FastAPI:
     app.state.event_bus = make_event_bus()
     app.state.ability_registry = SimpleAbilityRegistry()
     app.state.kg = SimpleKG()
-    app.state.llm_model = LLMClient()
+    app.state.llm_model = get_llm_client(os.getenv("LLM_MODEL"))
 
     # Mount routers
     app.include_router(agent_router)  # /v1/chat/stream

--- a/src/reug_runtime/llm_client.py
+++ b/src/reug_runtime/llm_client.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import asyncio
+import os
+from collections.abc import AsyncGenerator
+
+from .config import SETTINGS
+
+
+class LLMClient:
+    """Base class for streaming LLM providers."""
+
+    model_name: str
+
+    async def stream_chat(
+        self, messages: list[dict[str, str]], timeout: float | None = None
+    ) -> AsyncGenerator[dict[str, str], None]:
+        """Stream chat completion chunks.
+
+        Args:
+            messages: Conversation history.
+            timeout: Optional override for the streaming timeout.
+        """
+        raise NotImplementedError
+
+
+class GeminiClient(LLMClient):
+    """Client backed by google-generativeai."""
+
+    def __init__(self, model_name: str) -> None:
+        self.model_name = model_name
+        try:
+            import google.generativeai as genai  # type: ignore
+        except Exception:  # pragma: no cover - optional dependency
+            genai = None
+        key = os.getenv("GEMINI_API_KEY") or os.getenv("GOOGLE_API_KEY")
+        if genai and key:
+            genai.configure(api_key=key)
+            self._model = genai.GenerativeModel(model_name)
+        else:
+            self._model = None
+
+    async def stream_chat(
+        self, messages: list[dict[str, str]], timeout: float | None = None
+    ) -> AsyncGenerator[dict[str, str], None]:
+        if self._model is None:  # pragma: no cover - requires SDK
+            raise RuntimeError("Gemini SDK not available")
+        timeout = timeout or SETTINGS.model_stream_timeout_s
+        async with asyncio.timeout(timeout):
+            req = [m["content"] for m in messages]
+            resp = await self._model.generate_content_async(req, stream=True)
+            async for chunk in resp:
+                text = getattr(chunk, "text", "")
+                if not text:
+                    try:
+                        text = chunk.candidates[0].content.parts[0].text
+                    except Exception:
+                        text = ""
+                if text:
+                    yield {"content": text}
+
+
+class OpenAIClient(LLMClient):
+    """Client using the OpenAI async API."""
+
+    def __init__(self, model_name: str) -> None:
+        self.model_name = model_name
+        try:
+            from openai import AsyncOpenAI  # type: ignore
+        except Exception:  # pragma: no cover - optional dependency
+            AsyncOpenAI = None
+        api_key = os.getenv("OPENAI_API_KEY")
+        self._client = AsyncOpenAI(api_key=api_key) if AsyncOpenAI and api_key else None
+
+    async def stream_chat(
+        self, messages: list[dict[str, str]], timeout: float | None = None
+    ) -> AsyncGenerator[dict[str, str], None]:
+        if self._client is None:  # pragma: no cover - requires SDK
+            raise RuntimeError("OpenAI SDK not available")
+        timeout = timeout or SETTINGS.model_stream_timeout_s
+        async with asyncio.timeout(timeout):
+            stream = await self._client.chat.completions.create(
+                model=self.model_name,
+                messages=messages,
+                stream=True,
+            )
+            async for chunk in stream:
+                text = chunk.choices[0].delta.get("content", "")
+                if text:
+                    yield {"content": text}
+
+
+class AnthropicClient(LLMClient):
+    """Client using the Anthropic async API."""
+
+    def __init__(self, model_name: str) -> None:
+        self.model_name = model_name
+        try:
+            from anthropic import AsyncAnthropic  # type: ignore
+        except Exception:  # pragma: no cover - optional dependency
+            AsyncAnthropic = None
+        api_key = os.getenv("ANTHROPIC_API_KEY")
+        self._client = AsyncAnthropic(api_key=api_key) if AsyncAnthropic and api_key else None
+
+    async def stream_chat(
+        self, messages: list[dict[str, str]], timeout: float | None = None
+    ) -> AsyncGenerator[dict[str, str], None]:
+        if self._client is None:  # pragma: no cover - requires SDK
+            raise RuntimeError("Anthropic SDK not available")
+        timeout = timeout or SETTINGS.model_stream_timeout_s
+        async with asyncio.timeout(timeout):
+            stream = await self._client.messages.stream(
+                model=self.model_name,
+                messages=messages,
+            )
+            async for chunk in stream:
+                text = getattr(getattr(chunk, "delta", None), "text", "")
+                if not text and getattr(chunk, "message", None):
+                    try:
+                        text = chunk.message.content[0].text
+                    except Exception:
+                        text = ""
+                if text:
+                    yield {"content": text}
+
+
+class MockLLMClient(LLMClient):
+    """Deterministic mock used for development and tests."""
+
+    async def stream_chat(
+        self, messages: list[dict[str, str]], timeout: float | None = None
+    ) -> AsyncGenerator[dict[str, str], None]:
+        timeout = timeout or SETTINGS.model_stream_timeout_s
+        async with asyncio.timeout(timeout):
+            has_result = any(
+                m["role"] == "assistant" and "<tool_result" in m["content"]
+                for m in messages
+            )
+            if not has_result:
+                await asyncio.sleep(0)
+                yield {"content": "Thinking... "}
+                await asyncio.sleep(0)
+                yield {
+                    "content": '<tool_call>{"tool":"echo","args":{"payload":"hi"}}</tool_call>'
+                }
+            else:
+                await asyncio.sleep(0)
+                yield {
+                    "content": '<final_answer>{"content":"done: hi","citations":[]}</final_answer>'
+                }
+
+
+def get_llm_client(model_name: str | None) -> LLMClient:
+    """Factory selecting an LLM client based on model name."""
+    if not model_name:
+        return MockLLMClient()
+    m = model_name.lower()
+    if m.startswith("gemini"):
+        return GeminiClient(model_name)
+    if m.startswith("gpt") or m.startswith("openai"):
+        return OpenAIClient(model_name)
+    if m.startswith("claude"):
+        return AnthropicClient(model_name)
+    return MockLLMClient()
+
+
+__all__ = [
+    "LLMClient",
+    "GeminiClient",
+    "OpenAIClient",
+    "AnthropicClient",
+    "MockLLMClient",
+    "get_llm_client",
+]

--- a/src/reug_runtime/router.py
+++ b/src/reug_runtime/router.py
@@ -16,6 +16,7 @@ from collections.abc import AsyncGenerator
 from fastapi import APIRouter, Request
 from fastapi.responses import StreamingResponse
 from reug_runtime.config import SETTINGS
+from reug_runtime.llm_client import LLMClient
 
 
 # ==== Injected dependencies via app.state ====
@@ -26,9 +27,6 @@ class AbilityRegistry: ...
 
 
 class KnowledgeGraph: ...
-
-
-class LLMClient: ...  # wrapper around your provider
 
 
 router = APIRouter(prefix="/v1", tags=["agent"])

--- a/tests/runtime/fakes.py
+++ b/tests/runtime/fakes.py
@@ -3,6 +3,8 @@ import json
 from collections.abc import AsyncGenerator
 from typing import Any
 
+from reug_runtime.llm_client import LLMClient
+
 
 class FakeEventBus:
     def __init__(self) -> None:
@@ -86,14 +88,14 @@ class FakeKG:
         self.bonds.append({"type": bond_type, "src": source_atom_id, "tgt": target_atom_id})
 
 
-class FakeLLM:
+class FakeLLM(LLMClient):
     """Two-phase stream for deterministic tests."""
 
     def __init__(self) -> None:
         self._phase = 1
 
     async def stream_chat(
-        self, messages: list[dict[str, str]], timeout: float
+        self, messages: list[dict[str, str]], timeout: float | None = None
     ) -> AsyncGenerator[dict[str, str], None]:
         # detect if a tool_result was injected
         if any(m["role"] == "assistant" and "<tool_result" in m["content"] for m in messages):
@@ -110,3 +112,7 @@ class FakeLLM:
             await asyncio.sleep(0)
             final = json.dumps({"content": "done: hi", "citations": []})
             yield {"content": f"<final_answer>{final}</final_answer>"}
+
+
+# Alias for compatibility
+FakeLLMClient = FakeLLM

--- a/tests/runtime/test_llm_client.py
+++ b/tests/runtime/test_llm_client.py
@@ -1,0 +1,35 @@
+import asyncio
+import pytest
+
+from reug_runtime.llm_client import (
+    AnthropicClient,
+    GeminiClient,
+    MockLLMClient,
+    OpenAIClient,
+    get_llm_client,
+)
+from reug_runtime.config import SETTINGS
+
+
+def test_provider_selection() -> None:
+    assert isinstance(get_llm_client("gemini-1.5"), GeminiClient)
+    assert isinstance(get_llm_client("gpt-4"), OpenAIClient)
+    assert isinstance(get_llm_client("claude-3"), AnthropicClient)
+    assert isinstance(get_llm_client("other"), MockLLMClient)
+
+
+class SlowMock(MockLLMClient):
+    async def stream_chat(self, messages, timeout: float | None = None):
+        timeout = timeout or SETTINGS.model_stream_timeout_s
+        async with asyncio.timeout(timeout):
+            await asyncio.sleep(timeout + 0.1)
+            yield {"content": "late"}
+
+
+@pytest.mark.asyncio
+async def test_timeout_enforced(monkeypatch) -> None:
+    monkeypatch.setattr(SETTINGS, "model_stream_timeout_s", 0.01)
+    client = SlowMock()
+    with pytest.raises(TimeoutError):
+        async for _ in client.stream_chat([{"role": "user", "content": "hi"}]):
+            pass


### PR DESCRIPTION
## Summary
- add provider-specific streaming LLM clients with timeout support
- include fake client and tests covering selection and timeout
- wire router and app to use pluggable client module

## Changes
- new `reug_runtime.llm_client` with Gemini, OpenAI, Anthropic, and mock clients
- router imports shared `LLMClient`
- tests verify factory provider selection and timeout handling

## Verification
- `make deps`
- `pre-commit run --all-files`
- `pytest tests/runtime/test_llm_client.py -q`
- `pytest tests/runtime`

## Runtime impact
- honors `REUG_MODEL_STREAM_TIMEOUT_S` for all providers

## Observability
- no changes

## Rollback
- revert the commits


------
https://chatgpt.com/codex/tasks/task_e_68abc39d4a688328ba85d1cff023ef08