### PR TITLE
[runtime] add health checker

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -9,7 +9,8 @@ from collections.abc import AsyncGenerator
 from pathlib import Path
 from typing import Any
 
-from fastapi import FastAPI, Response
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
 
 # --- Resolve reug_runtime from local src if not installed ---
@@ -226,14 +227,30 @@ def create_app() -> FastAPI:
     )
 
     # Health for Dockerfile/compose
+    from reug_runtime.health import check_health
+
     @app.get("/healthz")
     async def health_check():
-        return Response(status_code=200)
+        status = await check_health(
+            app.state.event_bus,
+            app.state.ability_registry,
+            app.state.kg,
+            app.state.llm_model,
+        )
+        code = 200 if status["status"] == "healthy" else 503
+        return JSONResponse(status_code=code, content=status)
 
     # Alternative health endpoint
     @app.get("/health")
     async def health_check_alt():
-        return {"status": "healthy", "service": "super-alita"}
+        status = await check_health(
+            app.state.event_bus,
+            app.state.ability_registry,
+            app.state.kg,
+            app.state.llm_model,
+        )
+        code = 200 if status["status"] == "healthy" else 503
+        return JSONResponse(status_code=code, content=status)
 
     # Inject dependencies for the REUG router
     app.state.event_bus = make_event_bus()

--- a/src/reug_runtime/health.py
+++ b/src/reug_runtime/health.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+"""Shared health checks for runtime dependencies."""
+
+import contextlib
+from builtins import anext
+from typing import Any
+
+
+async def check_health(
+    event_bus: Any, ability_registry: Any, kg: Any, llm: Any
+) -> dict[str, Any]:
+    """Ping critical dependencies and return status map.
+
+    Args:
+        event_bus: Event emitter used for telemetry.
+        ability_registry: Registry responsible for tool contracts.
+        kg: Knowledge graph adapter.
+        llm: Language model client.
+
+    Returns:
+        Mapping with overall ``status`` and per-component details.
+    """
+    components: dict[str, dict[str, Any]] = {}
+    overall = "healthy"
+
+    # Event bus
+    try:
+        await event_bus.emit({"type": "health_check"})
+        components["event_bus"] = {"status": "ok"}
+    except Exception as e:  # pragma: no cover - exercised in tests
+        components["event_bus"] = {"status": "unhealthy", "error": str(e)}
+        overall = "unhealthy"
+
+    # Ability registry
+    try:
+        if hasattr(ability_registry, "health_check"):
+            await ability_registry.health_check({})
+        components["ability_registry"] = {"status": "ok"}
+    except Exception as e:  # pragma: no cover
+        components["ability_registry"] = {"status": "unhealthy", "error": str(e)}
+        overall = "unhealthy"
+
+    # Knowledge graph
+    try:
+        if hasattr(kg, "retrieve_relevant_context"):
+            await kg.retrieve_relevant_context("ping")
+        components["kg"] = {"status": "ok"}
+    except Exception as e:  # pragma: no cover
+        components["kg"] = {"status": "unhealthy", "error": str(e)}
+        overall = "unhealthy"
+
+    # LLM
+    try:
+        stream = llm.stream_chat([{"role": "user", "content": "ping"}], timeout=1)
+        try:
+            await anext(stream)
+        finally:
+            with contextlib.suppress(Exception):
+                await stream.aclose()
+        components["llm"] = {"status": "ok"}
+    except Exception as e:  # pragma: no cover
+        components["llm"] = {"status": "unhealthy", "error": str(e)}
+        overall = "unhealthy"
+
+    return {"status": overall, "components": components}

--- a/tests/runtime/test_health_endpoints.py
+++ b/tests/runtime/test_health_endpoints.py
@@ -1,0 +1,46 @@
+"""Health endpoint tests using fakes."""
+
+from fastapi.testclient import TestClient
+
+from src.main import create_app
+from tests.runtime.fakes import FakeAbilityRegistry, FakeEventBus, FakeKG, FakeLLM
+
+
+def _app_with_deps(event_bus, registry, kg, llm):
+    app = create_app()
+    app.state.event_bus = event_bus
+    app.state.ability_registry = registry
+    app.state.kg = kg
+    app.state.llm_model = llm
+    return app
+
+
+def test_health_endpoints_ok():
+    app = _app_with_deps(
+        FakeEventBus(), FakeAbilityRegistry(), FakeKG(), FakeLLM()
+    )
+    client = TestClient(app)
+    for path in ["/health", "/healthz"]:
+        resp = client.get(path)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "healthy"
+        assert data["components"]["event_bus"]["status"] == "ok"
+
+
+def test_health_endpoint_dependency_failure():
+    class BrokenBus(FakeEventBus):
+        async def emit(self, event):
+            raise RuntimeError("bus down")
+
+    app = _app_with_deps(
+        BrokenBus(), FakeAbilityRegistry(), FakeKG(), FakeLLM()
+    )
+    client = TestClient(app)
+    for path in ["/health", "/healthz"]:
+        resp = client.get(path)
+        assert resp.status_code == 503
+        data = resp.json()
+        assert data["status"] == "unhealthy"
+        assert data["components"]["event_bus"]["status"] == "unhealthy"
+        assert "bus down" in data["components"]["event_bus"]["error"]


### PR DESCRIPTION
## Summary
- add shared health checker that pings event bus, registry, KG, and LLM
- surface health results via `/health` and `/healthz` with 503 on failure
- test healthy and degraded cases with fakes

## Changes
- implement `check_health` helper
- wire FastAPI health endpoints to use shared checker
- add runtime health endpoint tests

## Verification
- `pre-commit run --all-files`
- `pytest -q tests/runtime`

## Runtime impact
- minimal overhead for health checks; endpoints return 503 when dependencies fail

## Observability
- health checks emit `health_check` events via the event bus

## Rollback
- revert commits `d49d326` and `fd321ac`

------
https://chatgpt.com/codex/tasks/task_e_68abc3a72c24832886c29f3285eff91c