### PR TITLE
[runtime] configurable startup components

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,4 +65,10 @@ For demo scripts such as `complete_agent_demo.py`, run a local Redis server
 Set `REUG_EVENTBUS=redis` to route telemetry through Redis/Memurai; otherwise
 events are appended to JSONL files under `REUG_EVENT_LOG_DIR`.
 
+Additional knobs:
+- `REDIS_URL`, `REUG_REDIS_CHANNEL` when using the Redis event bus
+- `REUG_REGISTRY` for ability registry backend
+- `REUG_KG` for knowledge graph backend
+- `REUG_LLM_PROVIDER` to force a specific LLM provider (`auto` picks by key)
+
 The `tests/` folder covers core utilities, planner logic, plugins, and integration flows.

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -8,8 +8,12 @@
    Optional knobs default safely:
 
    - `REUG_EVENTBUS` (`file` or `redis`)
+   - `REDIS_URL`, `REUG_REDIS_CHANNEL` (when `REUG_EVENTBUS=redis`)
    - `REUG_EVENT_LOG_DIR` (default `./logs/events`)
    - `REUG_TOOL_REGISTRY_DIR`
+   - `REUG_REGISTRY` (ability registry backend)
+   - `REUG_KG` (knowledge graph backend)
+   - `REUG_LLM_PROVIDER` (force LLM provider or `auto`)
    - `REUG_MAX_TOOL_CALLS`, `REUG_EXEC_TIMEOUT_S`, `REUG_EXEC_MAX_RETRIES`
    - `MCP_BROADCAST_URL` (optional MCP telemetry endpoint)
    - `MCP_BROADCAST_TOKEN` (bearer token for MCP_BROADCAST_URL)

--- a/tests/runtime/test_config_integration.py
+++ b/tests/runtime/test_config_integration.py
@@ -1,0 +1,26 @@
+"""Integration tests ensuring environment-driven configuration is applied."""
+
+from fastapi.testclient import TestClient
+
+from src.main import FileEventBus, create_app
+
+
+def test_config_round_trip(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("REUG_EVENTBUS", "file")
+    monkeypatch.setenv("REUG_EVENT_LOG_DIR", str(tmp_path / "logs"))
+    monkeypatch.setenv("REUG_TOOL_REGISTRY_DIR", str(tmp_path / "registry"))
+    monkeypatch.setenv("REUG_REGISTRY", "simple")
+    monkeypatch.setenv("REUG_KG", "simple")
+    monkeypatch.setenv("REUG_LLM_PROVIDER", "mock")
+    monkeypatch.setenv("REUG_MAX_TOOL_CALLS", "7")
+
+    app = create_app()
+    with TestClient(app) as client:
+        assert client.get("/healthz").status_code == 200
+        settings = app.state.settings
+        assert settings.max_tool_calls == 7
+        assert settings.event_bus_backend == "file"
+        assert settings.event_log_dir == str(tmp_path / "logs")
+        assert settings.tool_registry_dir == str(tmp_path / "registry")
+        assert isinstance(app.state.event_bus, FileEventBus)
+        assert app.state.llm_model._provider == "mock"

--- a/tests/runtime/test_main_app.py
+++ b/tests/runtime/test_main_app.py
@@ -8,17 +8,18 @@ from src.main import FileEventBus, create_app
 def test_create_app_smoke(tmp_path, monkeypatch) -> None:
     monkeypatch.setenv("REUG_EVENT_LOG_DIR", str(tmp_path))
     app = create_app()
-    client = TestClient(app)
+    with TestClient(app) as client:
+        resp = client.get("/healthz")
+        assert resp.status_code == 200
 
-    resp = client.get("/healthz")
-    assert resp.status_code == 200
+        resp = client.post(
+            "/v1/chat/stream", json={"message": "hello", "session_id": "s1"}
+        )
+        assert resp.status_code == 200
+        assert "<final_answer>" in resp.text
 
-    resp = client.post("/v1/chat/stream", json={"message": "hello", "session_id": "s1"})
-    assert resp.status_code == 200
-    assert "<final_answer>" in resp.text
-
-    # event bus writes to file
-    assert isinstance(app.state.event_bus, FileEventBus)
-    log = tmp_path / "events.jsonl"
-    assert log.exists()
-    assert log.read_text().strip()
+        # event bus writes to file
+        assert isinstance(app.state.event_bus, FileEventBus)
+        log = tmp_path / "events.jsonl"
+        assert log.exists()
+        assert log.read_text().strip()


### PR DESCRIPTION
## Summary
- extend runtime config with event bus, registry, KG, and LLM options
- initialize runtime dependencies on FastAPI startup/shutdown
- document new environment variables and add config round-trip test

## Changes
- add new Settings fields for service backends and provider
- use startup/shutdown events in `create_app`
- test env-driven configuration round-trip

## Verification
- `pre-commit run --all-files`
- `PYTHONPATH=./src pytest tests/runtime`

## Runtime impact
- reads environment once per app startup
- startup/shutdown hooks may add minor init/close latency

## Observability
- runtime components now configurable via env; event bus selection exposed

## Rollback
- revert commits or pin to previous revision

------
https://chatgpt.com/codex/tasks/task_e_68abc3a4aa288328ac7d45d90559239c