### PR TITLE
[cli] add health-check mode and tests

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -266,7 +266,49 @@ if __name__ == "__main__":
         action="store_true",
         help="Boot only; don’t open sockets beyond uvicorn",
     )
+    ap.add_argument(
+        "--reload",
+        action="store_true",
+        help="Reload server on code changes (dev mode)",
+    )
     args = ap.parse_args()
 
+    async def _dependency_health() -> dict[str, bool]:
+        results: dict[str, bool] = {}
+        try:
+            await app.state.event_bus.emit({"event": "health_check"})
+            results["event_bus"] = True
+        except Exception:
+            results["event_bus"] = False
+        try:
+            contract = app.state.ability_registry.get_available_tools_schema()[0]
+            results["ability_registry"] = await app.state.ability_registry.health_check(
+                contract
+            )
+        except Exception:
+            results["ability_registry"] = False
+        try:
+            await app.state.kg.get_goal_for_session("health")
+            results["kg"] = True
+        except Exception:
+            results["kg"] = False
+        try:
+            agen = app.state.llm_model.stream_chat([], timeout=1)
+            await agen.__anext__()
+            results["llm_model"] = True
+        except Exception:
+            results["llm_model"] = False
+        return results
+
+    if args.no_chat:
+        import asyncio
+        import json
+
+        checks = asyncio.run(_dependency_health())
+        print(json.dumps(checks))
+        raise SystemExit(0)
+
     # Just start the ASGI server; REUG handles single-turn streaming internally
-    uvicorn.run("main:app", host=args.host, port=args.port, reload=False)
+    uvicorn.run(
+        "main:app", host=args.host, port=args.port, reload=args.reload
+    )

--- a/tests/runtime/test_cli.py
+++ b/tests/runtime/test_cli.py
@@ -1,0 +1,57 @@
+"""CLI integration tests for startup modes."""
+
+import json
+import socket
+import subprocess
+import sys
+import time
+from urllib.request import urlopen
+
+
+def _free_port() -> int:
+    s = socket.socket()
+    s.bind(("", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def test_cli_no_chat_exits_with_health():
+    result = subprocess.run(
+        [sys.executable, "-m", "src.main", "--no-chat"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    data = json.loads(result.stdout.strip())
+    assert data["event_bus"]
+    assert data["ability_registry"]
+    assert data["kg"]
+    assert data["llm_model"]
+
+
+def test_cli_runs_uvicorn():
+    port = _free_port()
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "src.main", "--port", str(port)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    try:
+        for _ in range(40):
+            try:
+                resp = urlopen(f"http://127.0.0.1:{port}/healthz")
+                if resp.status == 200:
+                    break
+            except Exception:
+                time.sleep(0.25)
+        else:
+            raise AssertionError("server did not start")
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+    assert proc.returncode is not None


### PR DESCRIPTION
## Summary
- exit after app setup with dependency health report when `--no-chat` is passed
- expose `--reload` flag to forward to uvicorn for development
- cover CLI health-only and server modes with subprocess tests

## Changes
- extend `src/main.py` CLI options and add async dependency checks
- new `tests/runtime/test_cli.py` exercising both modes

## Verification
- `pre-commit run --all-files`
- `pytest -q tests/runtime`

## Runtime impact
- no change in default server path; health checks run only in `--no-chat` mode

## Observability
- prints JSON health summary when `--no-chat` is used; no telemetry schema changes

## Rollback
- revert commits `eaf8ff7`, `5e1c36a`, `6072dda`


------
https://chatgpt.com/codex/tasks/task_e_68abc3aa20088328b6f68e6caa805260