### PR TITLE
[runtime] Add JSON logging and startup telemetry

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -8,9 +8,63 @@ import sys
 from collections.abc import AsyncGenerator
 from pathlib import Path
 from typing import Any
+import logging
+from logging.config import dictConfig
+import json
+from uuid import uuid4
 
 from fastapi import FastAPI, Response
 from fastapi.middleware.cors import CORSMiddleware
+
+
+class JsonFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:  # pragma: no cover - simple
+        data = {
+            "time": self.formatTime(record, "%Y-%m-%dT%H:%M:%S"),
+            "level": record.levelname,
+            "name": record.name,
+            "message": record.getMessage(),
+        }
+        return json.dumps(data, ensure_ascii=False)
+
+
+def _configure_logging() -> Path:
+    log_dir = Path(os.getenv("REUG_LOG_DIR", "./logs"))
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_file = log_dir / "runtime.log"
+    dictConfig(
+        {
+            "version": 1,
+            "formatters": {"json": {"()": JsonFormatter}},
+            "handlers": {
+                "file": {
+                    "class": "logging.FileHandler",
+                    "filename": str(log_file),
+                    "formatter": "json",
+                    "encoding": "utf-8",
+                },
+                "console": {
+                    "class": "logging.StreamHandler",
+                    "formatter": "json",
+                },
+            },
+            "root": {
+                "level": os.getenv("REUG_LOG_LEVEL", "INFO"),
+                "handlers": ["file", "console"],
+            },
+        }
+    )
+    return log_file
+
+
+def _hash_json(obj: Any) -> str:
+    try:
+        import hashlib
+
+        h = hashlib.sha256(json.dumps(obj, sort_keys=True).encode("utf-8")).hexdigest()
+        return h[:16]
+    except Exception:
+        return "na"
 
 # --- Resolve reug_runtime from local src if not installed ---
 ROOT = Path(__file__).resolve().parent.parent
@@ -214,6 +268,8 @@ class LLMClient:
 
 # --- FastAPI factory ---
 def create_app() -> FastAPI:
+    _configure_logging()
+    logger = logging.getLogger(__name__)
     app = FastAPI(title="REUG Runtime", version="0.2.0")
 
     # CORS (tweak as needed)
@@ -246,6 +302,27 @@ def create_app() -> FastAPI:
     app.include_router(
         tools_router
     )  # /tools/* (toolbox – run tests, apply patches, etc.)
+
+    @app.on_event("startup")
+    async def _startup() -> None:
+        corr = str(uuid4())
+        logger.info("runtime startup")
+        await app.state.event_bus.emit(
+            {
+                "type": "STATE_TRANSITION",
+                "from": "BOOT",
+                "to": "READY",
+                "correlation_id": corr,
+            }
+        )
+        await app.state.event_bus.emit(
+            {
+                "type": "TaskStarted",
+                "correlation_id": corr,
+                "goal": "startup",
+                "user_msg_hash": _hash_json("startup"),
+            }
+        )
 
     return app
 

--- a/tests/runtime/test_logging.py
+++ b/tests/runtime/test_logging.py
@@ -1,0 +1,28 @@
+import asyncio
+import json
+import logging
+
+from src.main import create_app
+
+
+def test_logging_and_startup_events(tmp_path, monkeypatch) -> None:
+    log_dir = tmp_path / "logs"
+    event_dir = tmp_path / "events"
+    monkeypatch.setenv("REUG_LOG_DIR", str(log_dir))
+    monkeypatch.setenv("REUG_EVENT_LOG_DIR", str(event_dir))
+    app = create_app()
+    asyncio.run(app.router.startup())
+    logging.shutdown()
+
+    log_file = log_dir / "runtime.log"
+    assert log_file.exists()
+    lines = log_file.read_text().strip().splitlines()
+    assert lines
+    record = json.loads(lines[0])
+    assert record["message"] == "runtime startup"
+
+    events_file = event_dir / "events.jsonl"
+    assert events_file.exists()
+    events = [json.loads(l) for l in events_file.read_text().splitlines()]
+    kinds = {e["type"] for e in events}
+    assert {"STATE_TRANSITION", "TaskStarted"} <= kinds


### PR DESCRIPTION
## Summary
- configure runtime logging to JSON files with configurable directory via `REUG_LOG_DIR`
- emit `STATE_TRANSITION` and `TaskStarted` events when the app starts
- cover logging and telemetry with a regression test

## Changes
- add JSON formatter and logging configuration in `create_app`
- emit startup telemetry events and log startup message
- add `tests/runtime/test_logging.py`

## Verification
- `pre-commit run --all-files` *(fails: command not found)*
- `python3 -m pytest -q tests/runtime` *(fails: No module named pytest)*

## Runtime impact
- minimal startup work to configure logging and emit two telemetry events

## Observability
- startup produces JSON log line and event bus receives `STATE_TRANSITION` and `TaskStarted`

## Rollback
- revert these commits


------
https://chatgpt.com/codex/tasks/task_e_68abc3abdcf48328ada627024169f114