### PR TITLE
docs: detail runtime configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,13 +10,18 @@ REUG_RETRY_BASE_MS=250
 REUG_SCHEMA_ENFORCE=true
 
 # ===== Persistence & Logging =====
+REUG_EVENTBUS=file
+REUG_EVENTBUS_CHANNEL=reug.events
 REUG_EVENT_LOG_DIR=./logs/events
 REUG_TOOL_REGISTRY_DIR=./tools_registry
+REUG_KG_ADAPTER=memory
+REUG_KG_DIR=./kg
 # MCP telemetry endpoint (optional)
 MCP_BROADCAST_URL=
 MCP_BROADCAST_TOKEN=
 
 # ===== LLM Provider (choose one) =====
+REUG_LLM_PROVIDER=gemini
 # OPENAI_API_KEY=sk-your-key-here
 # GEMINI_API_KEY=your-gemini-key-here
 # ANTHROPIC_API_KEY=your-claude-key-here
@@ -48,8 +53,8 @@ YOUTUBE_API_KEY=your_youtube_key
 WOLFRAM_APP_ID=your_wolfram_id
 
 # LLM Configuration
-OPENAI_API_KEY=your_openai_key_here
-ANTHROPIC_API_KEY=your_anthropic_key_here
+# OPENAI_API_KEY=your_openai_key_here
+# ANTHROPIC_API_KEY=your_anthropic_key_here
 
 # Cache Configuration
 REDIS_URL=redis://localhost:6379

--- a/README.md
+++ b/README.md
@@ -23,7 +23,12 @@
 
 A FastAPI server exposes the REUG streaming router and toolbox. See
 [docs/runtime.md](docs/runtime.md) for local and Docker quick start guides,
-endpoint descriptions, and a Codex automation task.
+endpoint descriptions, and a Codex automation task. Setup knobs for:
+
+- [Event bus backends](docs/runtime.md#event-bus-backends)
+- [Registry persistence](docs/runtime.md#registry-persistence)
+- [Knowledge graph adapters](docs/runtime.md#knowledge-graph-adapters)
+- [LLM selection](docs/runtime.md#llm-selection)
 
 The optional `.codex/setup.sh` script installs dependencies and prepares a
 `.env` file for local runs.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -22,3 +22,17 @@ sequenceDiagram
 
 - **Deterministic Identity**: UUIDv5 seeded by normalized content + type + title.
 - **Provenance**: standardized in `meta.provenance` (source/activity/timestamp/context/parents).
+
+## Runtime dependency graph
+
+```mermaid
+graph TD
+    Router --> EventBus
+    Router --> Registry
+    Router --> LLM
+    Router --> KG
+    EventBus --> Redis[(Redis)]
+    EventBus --> File[(NDJSON)]
+    Registry --> FS[(Disk)]
+    KG --> Store[(Adapters)]
+```

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -87,3 +87,27 @@ Steps:
 ```
 
 This task will retry on failures and verify that streaming yields a `<final_answer>` block.
+
+## Event bus backends
+
+The runtime emits telemetry through a pluggable event bus. Set
+`REUG_EVENTBUS` to `file` (append NDJSON under `REUG_EVENT_LOG_DIR`) or
+`redis` (publish to `REUG_EVENTBUS_CHANNEL`). If the chosen backend is
+unavailable, events fall back to local JSONL logging.
+
+## Registry persistence
+
+Dynamic tools register with a file-backed registry so they survive
+process restarts. Point `REUG_TOOL_REGISTRY_DIR` at a writable directory to
+enable persistence.
+
+## Knowledge graph adapters
+
+Knowledge graph writes default to a JSONL store under `REUG_KG_DIR`. Swap
+adapters by setting `REUG_KG_ADAPTER` (for example, `memory` or `neo4j`) and
+providing any adapter-specific configuration.
+
+## LLM selection
+
+Choose the active language model by setting `REUG_LLM_PROVIDER` to `gemini`,
+`openai`, or `anthropic` and supplying the corresponding API key.


### PR DESCRIPTION
## Summary
- document runtime backends and persistence options
- cross-link setup guides and add dependency graph diagram
- provide env var samples for new configuration knobs

## Changes
- expand runtime docs with sections on event bus backends, registry persistence, KG adapters, and LLM selection
- link README to new runtime sections and add dependency graph diagram
- update `.env.example` with `REUG_EVENTBUS`, registry, KG, and LLM provider samples

## Verification
- `pre-commit run --all-files`
- `pytest -q tests/runtime`

## Runtime impact
- none

## Observability
- none

## Rollback
- revert this PR

------
https://chatgpt.com/codex/tasks/task_e_68abc3b1b4948328b0800f321eb1dc73