### PR TITLE
[runtime] test app factory

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = -q
+addopts = -q --cov=src/reug_runtime --cov-report=term --cov-fail-under=70
 asyncio_mode = auto
 markers =
     integration_redis: marks tests that require a running redis instance

--- a/tests/runtime/test_app_factory.py
+++ b/tests/runtime/test_app_factory.py
@@ -1,0 +1,47 @@
+from fastapi.testclient import TestClient
+
+from src.main import (
+    FileEventBus,
+    LLMClient,
+    SimpleAbilityRegistry,
+    SimpleKG,
+    create_app,
+)
+
+
+def test_app_factory_configures_app(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("REUG_EVENT_LOG_DIR", str(tmp_path))
+    monkeypatch.setenv(
+        "CORS_ALLOW_ORIGINS", "https://foo.com,https://bar.com"
+    )
+
+    app = create_app()
+
+    # dependencies exist on app.state
+    assert isinstance(app.state.event_bus, FileEventBus)
+    assert isinstance(app.state.ability_registry, SimpleAbilityRegistry)
+    assert isinstance(app.state.kg, SimpleKG)
+    assert isinstance(app.state.llm_model, LLMClient)
+
+    # routers registered
+    routes = {r.path for r in app.routes}
+    assert "/v1/chat/stream" in routes
+    assert "/tools/fs_read" in routes
+
+    # CORS config respects environment
+    cors = next(
+        (mw for mw in app.user_middleware if mw.cls.__name__ == "CORSMiddleware"),
+        None,
+    )
+    assert cors is not None
+    assert cors.kwargs["allow_origins"] == [
+        "https://foo.com",
+        "https://bar.com",
+    ]
+
+    client = TestClient(app)
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "healthy", "service": "super-alita"}
+    resp = client.get("/healthz")
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- add tests for app factory registration, state dependencies, CORS env override, and health endpoints
- enforce 70% coverage for runtime modules

## Changes
- add `tests/runtime/test_app_factory.py`
- update `pytest.ini` coverage settings

## Verification
- `pre-commit run --all-files`
- `pytest -q tests/runtime`

## Runtime impact
- none

## Observability
- none

## Rollback
- revert commit `d1742e3`


------
https://chatgpt.com/codex/tasks/task_e_68abc3b01394832894e9394720565f92