### PR TITLE
[runtime] expose Prometheus metrics

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -20,3 +20,6 @@ hypothesis>=6.0.0
 fakeredis>=2.0.0
 jsonschema>=4.0.0
 
+# Observability
+prometheus-client>=0.22.0
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,6 +40,9 @@ uvicorn[standard]>=0.24.0
 aiohttp>=3.9.5
 websockets>=12.0
 
+# Observability
+prometheus-client>=0.22.0
+
 # LLM integrations
 google-generativeai~=0.5.2
 

--- a/tests/runtime/test_metrics.py
+++ b/tests/runtime/test_metrics.py
@@ -1,0 +1,61 @@
+"""Verify Prometheus metrics export for runtime endpoints."""
+
+import asyncio
+import re
+
+from fastapi.testclient import TestClient
+
+from src.main import create_app
+
+
+def _metric_value(text: str, name: str, labels: dict[str, str]) -> float:
+    label_str = ",".join(f'{k}="{v}"' for k, v in labels.items())
+    pattern = rf"{name}{{{label_str}}} (\d+(?:\.\d+)?)"
+    match = re.search(pattern, text)
+    assert match, f"metric {name} with labels {labels} not found"
+    return float(match.group(1))
+
+
+def test_metrics_endpoint_tracks_requests_and_events() -> None:
+    app = create_app()
+    client = TestClient(app)
+
+    # Trigger request metrics
+    client.post("/v1/chat/stream", json={"message": "hi", "session_id": "m"})
+    client.get("/tools/catalog")
+
+    # Emit event bus metric
+    async def _emit() -> None:
+        await app.state.event_bus.emit({"type": "unit_event", "source": "test"})
+
+    asyncio.run(_emit())
+
+    resp = client.get("/metrics")
+    assert resp.status_code == 200
+    text = resp.text
+
+    assert (
+        _metric_value(
+            text,
+            "request_total",
+            {"endpoint": "/v1/chat/stream", "method": "POST", "status": "200"},
+        )
+        >= 1
+    )
+    assert (
+        _metric_value(
+            text,
+            "request_total",
+            {"endpoint": "/tools/catalog", "method": "GET", "status": "200"},
+        )
+        >= 1
+    )
+    assert (
+        _metric_value(
+            text,
+            "event_bus_messages_total",
+            {"event_type": "unit_event", "source": "test", "status": "success"},
+        )
+        >= 1
+    )
+


### PR DESCRIPTION
## Summary
- integrate prometheus-client and surface `/metrics` endpoint
- track request and event bus metrics for chat and tool routes
- exercise metrics export in runtime tests

## Changes
- add Prometheus counters/histograms and middleware in FastAPI app
- instrument FileEventBus and RedisEventBus for success/failure metrics
- register `prometheus-client` dependency
- add `test_metrics.py`

## Verification
- `pre-commit run --all-files`
- `pytest -q tests/runtime`

## Runtime impact
- per-request latency tracking; negligible overhead
- metrics recording limited to `/v1/chat/stream` and `/tools/*`

## Observability
- new metrics: `request_total`, `request_duration_seconds`, `event_bus_messages_total`, `event_bus_processing_duration_seconds`

## Rollback
- revert commits `c9a5678`, `6637d52`, `394c5d4`, `001a0cb`

------
https://chatgpt.com/codex/tasks/task_e_68abc3b58f608328ae3aeccc8648ec64