### PR TITLE
[runtime] Add terminal animation utility

### DIFF
--- a/src/utils/terminal_animation.py
+++ b/src/utils/terminal_animation.py
@@ -1,0 +1,42 @@
+"""Small helpers for dynamic terminal loading animations."""
+
+from __future__ import annotations
+
+import sys
+import time
+from typing import List, TextIO
+
+SPINNER_FRAMES = ["-", "\\", "|", "/"]
+
+def build_spinner_frames(prompt: str) -> List[str]:
+    """Build frames for a loading animation with dynamic prompt text.
+
+    Each frame shows a spinner character followed by the growing prefix
+    of the provided prompt. This allows callers to preview what is being
+    "made" as the animation progresses.
+    """
+    frames: List[str] = []
+    for i in range(1, len(prompt) + 1):
+        spinner = SPINNER_FRAMES[(i - 1) % len(SPINNER_FRAMES)]
+        frames.append(f"{spinner} {prompt[:i]}")
+    return frames
+
+def animate_prompt(prompt: str, delay: float = 0.1, stream: TextIO | None = None) -> None:
+    """Render a loading animation for the given prompt.
+
+    Parameters
+    ----------
+    prompt:
+        The text to gradually reveal alongside the spinner.
+    delay:
+        Seconds to pause between frames. Use ``0`` in tests.
+    stream:
+        Optional text stream. Defaults to ``sys.stdout``.
+    """
+    stream = stream or sys.stdout
+    for frame in build_spinner_frames(prompt):
+        stream.write(f"\r{frame}")
+        stream.flush()
+        time.sleep(delay)
+    stream.write("\n")
+    stream.flush()

--- a/tests/runtime/test_terminal_animation.py
+++ b/tests/runtime/test_terminal_animation.py
@@ -1,0 +1,22 @@
+"""Tests for terminal animation utilities."""
+
+# The animation helpers should provide deterministic frames so they can
+# be verified without rendering in a real terminal.
+
+from io import StringIO
+
+from src.utils.terminal_animation import animate_prompt, build_spinner_frames
+
+
+def test_build_spinner_frames_dynamic():
+    frames = build_spinner_frames("Hi")
+    assert frames == ["- H", "\\ Hi"]
+
+
+def test_animate_prompt_writes_frames():
+    buf = StringIO()
+    animate_prompt("OK", delay=0, stream=buf)
+    output = buf.getvalue()
+    assert output.startswith("\r- O")
+    assert "\r\\ OK" in output
+    assert output.endswith("\n")


### PR DESCRIPTION
## Summary
- provide helper to render prompt-driven terminal loading animation
- expose `LLMClient` from main entrypoint and refine `/health` response
- cover new animation behavior with tests

## Changes
- add `terminal_animation` helper
- conditionally minimize `/health` output when default dependencies active
- document and test spinner frame generation

## Verification
- `pre-commit run --all-files`
- `pytest -q tests/runtime`

## Runtime impact
- optional animation utility has no effect unless invoked; health endpoint now checks dependency types before returning minimal payload

## Observability
- existing logging and health telemetry preserved; no new fields emitted

## Rollback
- revert commits `237e520`, `02b7d41`, and `24d6298`

------
https://chatgpt.com/codex/tasks/task_e_68abd4b1992c83289519190b47b9ff7f