### PR TITLE
[deepcode] Sync DeepCode outputs to Puter

### DIFF
--- a/docs/PUTER_INTEGRATION.md
+++ b/docs/PUTER_INTEGRATION.md
@@ -156,6 +156,15 @@ The atoms include:
 5. **History Tracked**: Operation stored in plugin history
 6. **Shutdown Storage**: Atoms registered with neural store on shutdown
 
+## DeepCode
+
+DeepCode proposals are mirrored to Puter so the cloud workspace reflects
+generated code. The `deepcode_puter_bridge` plugin listens for
+`deepcode_ready_for_apply` events and emits `puter_file_write` events for
+each proposed diff, test, and doc. The Puter plugin consumes these events,
+performs the writes, and records a `PuterOperationAtom` for every file to
+maintain lineage.
+
 ## Security Features
 
 ### Workspace Boundary Validation

--- a/src/main_unified.py
+++ b/src/main_unified.py
@@ -67,6 +67,7 @@ def _load_unified_plugins():
         ),
         # Cloud integration plugins
         ("src.plugins.puter_plugin", "PuterPlugin", "puter"),
+        ("src.plugins.deepcode_puter_bridge_plugin", "DeepCodePuterBridgePlugin", "deepcode_puter_bridge"),
         # AI-powered search plugin
         ("src.plugins.perplexica_search_plugin", "PerplexicaSearchPlugin", "perplexica_search"),
         # Legacy plugins (fallback compatibility)

--- a/src/plugins/deepcode_orchestrator_plugin.py
+++ b/src/plugins/deepcode_orchestrator_plugin.py
@@ -201,6 +201,8 @@ class DeepCodeOrchestratorPlugin(PluginInterface):
                     correlation_id=correlation_id,
                     timestamp=_utcnow(),
                     diffs=diffs,
+                    tests=impl.get("tests", []),
+                    docs=impl.get("docs", []),
                     validation_summary={
                         "lint_errors": validation.get("lint_errors", 0),
                         "tests_passed": validation.get("tests_passed", True),

--- a/src/plugins/deepcode_puter_bridge_plugin.py
+++ b/src/plugins/deepcode_puter_bridge_plugin.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Bridge DeepCode outputs to Puter file writes."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from src.core.plugin_interface import PluginInterface
+
+
+class DeepCodePuterBridgePlugin(PluginInterface):
+    """Subscribe to DeepCode results and mirror files to Puter."""
+
+    @property
+    def name(self) -> str:  # pragma: no cover - trivial
+        return "deepcode_puter_bridge"
+
+    async def setup(self, event_bus: Any, store: Any, config: dict[str, Any]) -> None:  # pragma: no cover - simple
+        await super().setup(event_bus, store, config)
+
+    async def start(self) -> None:
+        await super().start()
+        await self.subscribe("deepcode_ready_for_apply", self._on_ready)
+
+    async def _on_ready(self, event: Any) -> None:
+        # Collect all proposed files (diffs, tests, docs)
+        files: list[tuple[str, str]] = []
+
+        for diff in getattr(event, "diffs", []) or []:
+            files.append((diff.get("path", ""), diff.get("new_content", "")))
+        for test in getattr(event, "tests", []) or []:
+            files.append((test.get("path", ""), test.get("content", "")))
+        for doc in getattr(event, "docs", []) or []:
+            files.append((doc.get("path", ""), doc.get("content", "")))
+
+        for path, content in files:
+            if not path:
+                continue
+            await self.emit_event(
+                "puter_file_write",
+                file_path=path,
+                content=content,
+                conversation_id=getattr(event, "conversation_id", None),
+                correlation_id=getattr(event, "correlation_id", None),
+                request_id=getattr(event, "request_id", None),
+                proposal_id=getattr(event, "proposal_id", None),
+                timestamp=datetime.now(timezone.utc),
+            )

--- a/src/plugins/puter_plugin.py
+++ b/src/plugins/puter_plugin.py
@@ -82,6 +82,7 @@ class PuterPlugin(PluginInterface):
         await self.subscribe("puter_file_operation", self._handle_file_operation)
         await self.subscribe("puter_process_execution", self._handle_process_execution)
         await self.subscribe("puter_workspace_sync", self._handle_workspace_sync)
+        await self.subscribe("puter_file_write", self._handle_direct_file_write)
         
         # Subscribe to general tool calls that might need Puter
         await self.subscribe("tool_call", self._handle_tool_call)
@@ -150,6 +151,20 @@ class PuterPlugin(PluginInterface):
                 source_plugin=self.name,
                 conversation_id=getattr(event, 'conversation_id', 'unknown'),
             )
+
+    async def _handle_direct_file_write(self, event: BaseEvent) -> None:
+        """Handle simple puter_file_write events by delegating to file_operation."""
+        file_event = create_event(
+            "puter_file_operation",
+            source_plugin=self.name,
+            conversation_id=getattr(event, "conversation_id", "unknown"),
+        )
+        file_event.metadata = {
+            "operation": "write",
+            "file_path": getattr(event, "file_path", ""),
+            "content": getattr(event, "content", ""),
+        }
+        await self._handle_file_operation(file_event)
 
     async def _handle_process_execution(self, event: BaseEvent) -> None:
         """Handle process execution in Puter cloud environment."""

--- a/tests/runtime/test_deepcode_orchestrator.py
+++ b/tests/runtime/test_deepcode_orchestrator.py
@@ -1,0 +1,55 @@
+import asyncio
+from collections import defaultdict
+
+import pytest
+
+from src.plugins.deepcode_orchestrator_plugin import DeepCodeOrchestratorPlugin
+from src.plugins.deepcode_puter_bridge_plugin import DeepCodePuterBridgePlugin
+from src.plugins.puter_plugin import PuterPlugin
+from src.core.events import create_event
+
+
+class FakeBus:
+    def __init__(self) -> None:
+        self._subs: dict[str, list] = defaultdict(list)
+        self.events = []
+
+    async def subscribe(self, event_type: str, handler):
+        self._subs[event_type].append(handler)
+
+    async def publish(self, event):
+        self.events.append(event)
+        for handler in self._subs.get(event.event_type, []):
+            await handler(event)
+
+    async def emit(self, event_type: str, **kwargs):
+        event = create_event(event_type, **kwargs)
+        await self.publish(event)
+        return event
+
+
+@pytest.mark.asyncio
+async def test_deepcode_diffs_mirrored_to_puter():
+    bus = FakeBus()
+    dc_plugin = DeepCodeOrchestratorPlugin()
+    bridge = DeepCodePuterBridgePlugin()
+    puter = PuterPlugin()
+
+    for plugin in (dc_plugin, bridge, puter):
+        await plugin.setup(bus, store=None, config={})
+        await plugin.start()
+
+    await dc_plugin._on_request(
+        {"request_id": "req1", "task_kind": "text2code", "requirements": "test", "conversation_id": "c1"}
+    )
+
+    await asyncio.sleep(0.5)
+
+    write_events = [e for e in bus.events if e.event_type == "puter_file_write"]
+    assert len(write_events) == 3
+    paths = {e.file_path for e in write_events}
+    assert {"docs/deepcode_result.md", "tests/test_deepcode_result.py", "docs/plan.json"} == paths
+
+    assert len(puter.operation_history) == 3
+    hist_paths = {atom.operation_data["file_path"] for atom in puter.operation_history}
+    assert paths == hist_paths


### PR DESCRIPTION
## Summary
- Mirror DeepCode proposals to Puter via new bridge plugin
- Handle `puter_file_write` events in Puter plugin and record lineage atoms
- Document DeepCode->Puter workflow and test cloud mirroring

## Changes
- add `deepcode_puter_bridge` plugin that forwards DeepCode diffs/tests/docs as `puter_file_write` events
- extend DeepCode orchestrator `deepcode_ready_for_apply` payload with tests/docs
- allow Puter plugin to consume `puter_file_write` events and store `PuterOperationAtom`
- register bridge plugin in unified plugin list and document workflow
- add integration test ensuring DeepCode writes are mirrored to Puter

## Verification
- `pre-commit run --all-files`
- `pytest -q tests/runtime`

## Runtime impact
- Minor: additional event processing when DeepCode completes; negligible latency

## Observability
- Each mirrored file emits `puter_file_write` and results in a `PuterOperationAtom`

## Rollback
- Revert commits `67b3944` and `183a696`

------
https://chatgpt.com/codex/tasks/task_e_68abe02da36483289d23e787c7a91926