### PR TITLE
[plugins] Persist Perplexica search memory

### DIFF
--- a/docs/perplexica_integration.md
+++ b/docs/perplexica_integration.md
@@ -82,6 +82,17 @@ await plugin.setup(event_bus, store, config)
 response = await plugin.search("Python tutorials", SearchMode.WEB)
 ```
 
+## Memory Persistence
+
+Each search response is persisted as a `TextualMemoryAtom` in the shared
+`NeuralStore`. Plugins can retrieve recent searches via
+`get_recent_search()`, which returns the stored atoms for downstream use.
+
+To archive search results externally, enable the optional
+`archive_to_puter` configuration. When set, the plugin triggers a
+`puter_file_write` tool call that writes the JSON response to Puter
+cloud storage.
+
 ## Configuration
 
 ### Environment Variables

--- a/src/plugins/perplexica_search_plugin.py
+++ b/src/plugins/perplexica_search_plugin.py
@@ -10,13 +10,15 @@ import json
 import logging
 import time
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional, Union
 from enum import Enum
+from typing import Any, Dict, List, Optional, Union
 from urllib.parse import urlparse
+from uuid import uuid4
 
 import aiohttp
 from pydantic import BaseModel, Field
 
+from src.core.neural_atom import NeuralAtomMetadata, TextualMemoryAtom
 from src.core.plugin_interface import PluginInterface
 from src.core.events import BaseEvent, create_event
 
@@ -95,6 +97,7 @@ class PerplexicaSearchPlugin(PluginInterface):
         self.web_agent: Optional[Any] = None
         self.llm_client: Optional[Any] = None
         self.search_history: List[PerplexicaResponse] = []
+        self._memory_keys: List[str] = []
         self.mode_handlers = {
             SearchMode.WEB: self._search_web,
             SearchMode.ACADEMIC: self._search_academic,
@@ -202,6 +205,43 @@ class PerplexicaSearchPlugin(PluginInterface):
                 session_id=session_id,
                 search_mode=search_mode.value
             )
+
+            # Persist search result to memory
+            if self.store:
+                try:
+                    metadata = NeuralAtomMetadata(
+                        name=f"perplexica_{uuid4().hex[:8]}",
+                        description=f"Perplexica search for '{query}'",
+                        capabilities=["memory", "search"],
+                        tags={"perplexica", "search", search_mode.value},
+                    )
+                    memory_atom = TextualMemoryAtom(
+                        metadata=metadata,
+                        content=json.dumps(response.model_dump()),
+                    )
+                    self.store.register(memory_atom)
+                    self._memory_keys.append(memory_atom.key)
+                except Exception as mem_exc:
+                    logger.warning(f"Failed to store search memory: {mem_exc}")
+
+            # Optionally archive response to Puter
+            if self.config.get("archive_to_puter"):
+                try:
+                    await self.emit_event(
+                        "tool_call",
+                        tool_name="puter_file_write",
+                        parameters={
+                            "file_path": f"/perplexica/{session_id}_{int(time.time())}.json",
+                            "content": json.dumps(response.model_dump()),
+                        },
+                        session_id=session_id,
+                        conversation_id=session_id,
+                        tool_call_id=f"puter_archive_{uuid4().hex[:8]}",
+                    )
+                except Exception as puter_exc:
+                    logger.warning(
+                        f"Failed to archive search result to Puter: {puter_exc}"
+                    )
 
             # Also emit as tool result for compatibility
             from src.core.events import ToolResultEvent
@@ -546,6 +586,17 @@ Please provide a detailed analysis that synthesizes the information and highligh
         if not self.search_history:
             return []
         return list(self.search_history[-limit:])
+
+    def get_recent_search(self, limit: int = 5) -> List[TextualMemoryAtom]:
+        """Return recently stored search memory atoms."""
+        if not self.store or not self._memory_keys:
+            return []
+        atoms: List[TextualMemoryAtom] = []
+        for key in self._memory_keys[-limit:]:
+            atom = self.store.get(key)
+            if atom:
+                atoms.append(atom)
+        return atoms
 
     def get_tools(self) -> List[Dict[str, Any]]:
         """Return available tools for this plugin."""

--- a/tests/plugins/test_perplexica_search_plugin.py
+++ b/tests/plugins/test_perplexica_search_plugin.py
@@ -1,6 +1,14 @@
 """Tests for Perplexica search plugin."""
+from unittest.mock import AsyncMock
+
 import pytest
 from src.tools.perplexica_tool import PerplexicaSearchTool, PerplexicaConfig
+from src.plugins.perplexica_search_plugin import (
+    PerplexicaResponse,
+    PerplexicaSearchPlugin,
+    SearchMode,
+)
+from src.core.neural_atom import TextualMemoryAtom
 
 
 @pytest.fixture
@@ -136,3 +144,55 @@ async def test_all_modes(search_tool, mode):
     assert result["mode"] == mode
     assert "summary" in result
     assert result["confidence"] >= 0
+
+
+class DummyEventBus:
+    def __init__(self):
+        self.events = []
+
+    async def publish(self, event):
+        self.events.append(event)
+
+    async def subscribe(self, event_type, handler):
+        pass
+
+
+class DummyStore:
+    def __init__(self):
+        self.atoms = {}
+
+    def register(self, atom):
+        self.atoms[atom.key] = atom
+
+    def get(self, key):
+        return self.atoms.get(key)
+
+
+@pytest.mark.asyncio
+async def test_memory_atom_storage():
+    bus = DummyEventBus()
+    store = DummyStore()
+    plugin = PerplexicaSearchPlugin()
+    await plugin.setup(bus, store, {"archive_to_puter": True})
+
+    fake_resp = PerplexicaResponse(
+        query="foo",
+        search_mode=SearchMode.WEB,
+        summary="s",
+        reasoning="r",
+        sources=[],
+        citations=[],
+    )
+
+    plugin.search = AsyncMock(return_value=fake_resp)
+
+    await plugin._handle_search_request(
+        {"query": "foo", "search_mode": "web", "session_id": "s1", "tool_call_id": "t1"}
+    )
+
+    atoms = plugin.get_recent_search()
+    assert len(atoms) == 1
+    assert isinstance(atoms[0], TextualMemoryAtom)
+
+    tool_events = [e for e in bus.events if getattr(e, "event_type", "") == "tool_call"]
+    assert tool_events and tool_events[0].tool_name == "puter_file_write"


### PR DESCRIPTION
## Summary
- persist Perplexica search results as `TextualMemoryAtom`s and optionally archive to Puter
- expose `get_recent_search` helper for retrieving stored search atoms
- document memory persistence and add unit test

## Changes
- store search responses in NeuralStore and emit optional `puter_file_write`
- retrieval helper for recent searches
- test coverage for memory atom creation and Puter archive event
- docs describe memory persistence and Puter archiving

## Verification
- `pre-commit run --all-files`
- `pytest -q tests/runtime`
- `pytest --no-cov tests/plugins/test_perplexica_search_plugin.py::test_memory_atom_storage`

## Runtime impact
- minimal: single atom creation per search plus optional Puter write

## Observability
- search memory persisted as atoms; Puter writes logged via `tool_call`

## Rollback
- revert this PR and restart the service

------
https://chatgpt.com/codex/tasks/task_e_68abe035c7388328bb04b9927904950e