### PR TITLE
logging: replace prints with structured logs

### DIFF
--- a/src/planning/sync_once.py
+++ b/src/planning/sync_once.py
@@ -208,22 +208,22 @@ async def main():
         demo_anti_thrash_protection()
         return
 
-    print("🚀 Super Alita: Metrics → Todos Synchronization")
-    print("=" * 60)
+    logger.info("🚀 Super Alita: Metrics → Todos Synchronization")
+    logger.info("=" * 60)
 
     result = await sync_metrics_to_todos()
 
     if result["success"]:
-        print("✅ Sync completed successfully!")
-        print(f"  📊 Processed {result['metrics_processed']} metrics")
-        print(f"  📝 Took {result['actions_taken']} todo actions")
-        print(f"  📋 {result['active_todos']} active todos")
-        print(f"  ⚠️  Risk score: {result['risk_score']:.3f}")
-        print(f"  🎯 System priority: {result['system_priority']}")
-        print(f"  ⏱️  Completed in {result['elapsed_s']:.2f}s")
+        logger.info("✅ Sync completed successfully!")
+        logger.info(f"  📊 Processed {result['metrics_processed']} metrics")
+        logger.info(f"  📝 Took {result['actions_taken']} todo actions")
+        logger.info(f"  📋 {result['active_todos']} active todos")
+        logger.info(f"  ⚠️  Risk score: {result['risk_score']:.3f}")
+        logger.info(f"  🎯 System priority: {result['system_priority']}")
+        logger.info(f"  ⏱️  Completed in {result['elapsed_s']:.2f}s")
         sys.exit(0)
     else:
-        print(f"❌ Sync failed: {result['error']}")
+        logger.error(f"❌ Sync failed: {result['error']}")
         sys.exit(1)
 
 

--- a/src/plugins/core_utils_plugin_dynamic.py
+++ b/src/plugins/core_utils_plugin_dynamic.py
@@ -5,6 +5,7 @@ all public methods from CoreUtils without hardcoding.
 """
 
 import inspect
+import logging
 import time
 from collections.abc import Callable
 from typing import Any
@@ -12,6 +13,9 @@ from typing import Any
 from src.core.events import BaseEvent, ToolCallEvent
 from src.core.plugin_interface import PluginInterface
 from src.tools.core_utils import CoreUtils
+
+
+logger = logging.getLogger(__name__)
 
 
 class CoreUtilsPlugin(PluginInterface):
@@ -75,10 +79,13 @@ class CoreUtilsPlugin(PluginInterface):
                 "discovered_dynamically": True,
             }
 
-        print(f"🔍 Dynamically discovered {len(self._capabilities)} capabilities:")
+        logger.info("🔍 Dynamically discovered %d capabilities:", len(self._capabilities))
         for tool_name, metadata in self._capability_metadata.items():
-            print(
-                f"  • {tool_name}{metadata['signature']} - {metadata['docstring'][:50]}..."
+            logger.debug(
+                "  • %s%s - %s...",
+                tool_name,
+                metadata["signature"],
+                metadata["docstring"][:50],
             )
 
     async def _register_discovered_capabilities(self):
@@ -111,7 +118,9 @@ class CoreUtilsPlugin(PluginInterface):
                 )
                 await self.event_bus.publish(discovery_event)
             except Exception as e:
-                print(f"⚠️ Warning: Could not publish capability discovery event: {e}")
+                logger.warning(
+                    "⚠️ Warning: Could not publish capability discovery event: %s", e
+                )
                 # Continue anyway - this is not critical for operation
 
     async def start(self):
@@ -119,8 +128,10 @@ class CoreUtilsPlugin(PluginInterface):
         await super().start()
         await self.subscribe("tool_call", self._handle_dynamic_tool_call)
 
-        print(
-            f"✅ {self.name} plugin started with {len(self._capabilities)} dynamic capabilities"
+        logger.info(
+            "✅ %s plugin started with %d dynamic capabilities",
+            self.name,
+            len(self._capabilities),
         )
 
     async def _handle_dynamic_tool_call(self, event: ToolCallEvent):
@@ -215,8 +226,10 @@ class CoreUtilsPlugin(PluginInterface):
 
     async def shutdown(self):
         """Clean shutdown of dynamic capabilities."""
-        print(
-            f"🔄 Shutting down {self.name} with {len(self._capabilities)} dynamic capabilities"
+        logger.info(
+            "🔄 Shutting down %s with %d dynamic capabilities",
+            self.name,
+            len(self._capabilities),
         )
         self._capabilities.clear()
         self._capability_metadata.clear()

--- a/tests/runtime/test_logging_events_replacement.py
+++ b/tests/runtime/test_logging_events_replacement.py
@@ -1,0 +1,78 @@
+import json
+import logging
+
+import json
+import logging
+
+import pytest
+
+from src.plugins.core_utils_plugin_dynamic import CoreUtilsPlugin
+from src.planning import sync_once
+import todo_sync
+
+
+class DummyEventBus:
+    def __init__(self) -> None:
+        self.events: list = []
+
+    async def publish(self, event) -> None:  # pragma: no cover - simple stub
+        self.events.append(event)
+
+    async def subscribe(self, event_type, handler) -> None:  # pragma: no cover
+        pass
+
+
+class DummyStore:
+    async def register_capabilities(self, name: str, data: dict) -> None:  # pragma: no cover
+        self.name = name
+        self.data = data
+
+
+@pytest.mark.asyncio
+async def test_core_utils_plugin_discovers_and_logs(caplog):
+    caplog.set_level(logging.INFO)
+    plugin = CoreUtilsPlugin()
+    bus = DummyEventBus()
+    store = DummyStore()
+
+    await plugin.setup(bus, store, config={})
+    await plugin.start()
+
+    assert any("plugin started" in r.getMessage() for r in caplog.records)
+    assert any(e.event_type == "capabilities_discovered" for e in bus.events)
+
+
+@pytest.mark.asyncio
+async def test_sync_once_main_logs(monkeypatch, caplog):
+    caplog.set_level(logging.INFO)
+
+    async def fake_sync() -> dict:
+        return {
+            "success": True,
+            "metrics_processed": 1,
+            "actions_taken": 1,
+            "active_todos": 1,
+            "risk_score": 0.1,
+            "system_priority": "low",
+            "elapsed_s": 0.01,
+        }
+
+    monkeypatch.setattr(sync_once, "sync_metrics_to_todos", fake_sync)
+    exit_code: dict[str, int] = {}
+    monkeypatch.setattr(sync_once.sys, "exit", lambda code: exit_code.setdefault("code", code))
+
+    await sync_once.main()
+
+    assert exit_code["code"] == 0
+    assert any("Sync completed successfully" in r.getMessage() for r in caplog.records)
+
+
+def test_todo_sync_logging(tmp_path, monkeypatch, caplog):
+    todo_file = tmp_path / "todos.json"
+    todo_file.write_text(json.dumps({"todoList": [], "lastModified": ""}))
+    monkeypatch.setattr(todo_sync, "TODO_FILE", todo_file)
+    caplog.set_level(logging.INFO)
+
+    todo_sync.update_persistent_todos([{"title": "x"}])
+
+    assert any("Updated 1 todos" in r.getMessage() for r in caplog.records)

--- a/todo_sync.py
+++ b/todo_sync.py
@@ -3,8 +3,13 @@
 Todo Integration Script - Syncs active todos with persistent storage
 """
 import json
+import logging
 import sys
+from datetime import datetime
 from pathlib import Path
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 TODO_FILE = Path(__file__).parent / '.vscode' / 'todos.json'
 
@@ -21,10 +26,10 @@ def update_persistent_todos(new_todos):
             
             with open(TODO_FILE, 'w', encoding='utf-8') as f:
                 json.dump(data, f, indent=2, ensure_ascii=False)
-                
-            print(f"📋 Updated {len(new_todos)} todos in persistent storage")
+
+            logger.info("📋 Updated %d todos in persistent storage", len(new_todos))
         except Exception as e:
-            print(f"❌ Error updating todos: {e}")
+            logger.error("❌ Error updating todos: %s", e)
 
 if __name__ == "__main__":
     # Read todos from stdin (for integration with manage_todo_list tool)
@@ -34,6 +39,6 @@ if __name__ == "__main__":
             todos = json.loads(todo_json)
             update_persistent_todos(todos)
         except json.JSONDecodeError:
-            print("❌ Invalid JSON provided")
+            logger.error("❌ Invalid JSON provided")
     else:
-        print("💡 Todo integration script ready for use")
+        logger.info("💡 Todo integration script ready for use")


### PR DESCRIPTION
## Summary
- replace `print` usage with `logging` in sync and plugin utilities
- add regression tests for log and event emission

## Changes
- convert console prints to structured `logging` in `sync_once`, `core_utils_plugin_dynamic`, and `todo_sync`
- surface capability discovery warnings via logger
- add tests validating log output and discovery events

## Verification
- `pre-commit run --all-files`
- `pytest tests/runtime/test_logging_events_replacement.py -q`
- `pytest -q tests/runtime` *(fails: ImportError: cannot import name 'BlockParser' from 'reug_runtime.router')*

## Runtime impact
- negligible; replaces stdout prints with standard logging handlers

## Observability
- capability discovery and sync operations now emit structured logs, enabling collection by existing log handlers

## Rollback
- revert this PR's commits

------
https://chatgpt.com/codex/tasks/task_e_68ac32723f188328a8c94416dea83ffa