### PR TITLE
mcp_server: add result-return transform

### DIFF
--- a/src/mcp_server/ast_utils.py
+++ b/src/mcp_server/ast_utils.py
@@ -1,15 +1,68 @@
 from __future__ import annotations
 
 from difflib import unified_diff
+import libcst as cst
+
+
+class _ReturnResultTransformer(cst.CSTTransformer):
+    def __init__(self, function_name: str) -> None:
+        self.function_name = function_name
+        self.found = False
+        self.result_var: str | None = None
+
+    def leave_FunctionDef(
+        self, original_node: cst.FunctionDef, updated_node: cst.FunctionDef
+    ) -> cst.FunctionDef:
+        if original_node.name.value != self.function_name:
+            return updated_node
+
+        self.found = True
+        body_stmts = list(updated_node.body.body)
+        if body_stmts and isinstance(
+            body_stmts[-1], cst.SimpleStatementLine
+        ) and any(isinstance(s, cst.Return) for s in body_stmts[-1].body):
+            return updated_node
+
+        last_assign: str | None = None
+        for stmt in body_stmts:
+            if isinstance(stmt, cst.SimpleStatementLine):
+                for small in stmt.body:
+                    if (
+                        isinstance(small, cst.Assign)
+                        and isinstance(small.targets[0].target, cst.Name)
+                    ):
+                        last_assign = small.targets[0].target.value
+
+        if last_assign is None:
+            return updated_node
+
+        self.result_var = last_assign
+        return_stmt = cst.SimpleStatementLine(
+            [cst.Return(cst.Name(last_assign))]
+        )
+        new_body = body_stmts + [return_stmt]
+        return updated_node.with_changes(
+            body=updated_node.body.with_changes(body=new_body)
+        )
 
 
 def rewrite_function_to_result(
     src: str, function_name: str
 ) -> tuple[str | None, str | None]:
-    # TODO: Replace with a real libcst transform.
-    if f"def {function_name}(" not in src:
+    try:
+        module = cst.parse_module(src)
+    except Exception as e:
+        return None, str(e)
+
+    transformer = _ReturnResultTransformer(function_name)
+    new_module = module.visit(transformer)
+
+    if not transformer.found:
         return None, "Function not found"
-    new_src = src  # placeholder; no-op transform for demo
+    if transformer.result_var is None:
+        return None, "Could not determine result variable"
+
+    new_src = new_module.code
     diff = "".join(
         unified_diff(
             src.splitlines(keepends=True),

--- a/tests/mcp_server/test_ast_utils.py
+++ b/tests/mcp_server/test_ast_utils.py
@@ -1,0 +1,12 @@
+from mcp_server.ast_utils import rewrite_function_to_result
+
+
+def test_rewrite_function_to_result_adds_return_and_diff():
+    src = """
+def target():
+    result = 1 + 1
+"""
+    rewritten, diff = rewrite_function_to_result(src, "target")
+    assert rewritten is not None
+    assert "return result" in rewritten
+    assert "+    return result" in diff

--- a/tests/mcp_server/test_tools.py
+++ b/tests/mcp_server/test_tools.py
@@ -1,0 +1,12 @@
+import pytest
+
+from mcp_server.tools import refactor_to_result
+
+
+@pytest.mark.asyncio
+async def test_refactor_to_result_handles_missing_function(tmp_path):
+    file = tmp_path / "mod.py"
+    file.write_text("def foo():\n    return 1\n", encoding="utf-8")
+    res = await refactor_to_result(str(file), "missing")
+    assert res["applied"] is False
+    assert res["error"]


### PR DESCRIPTION
## Summary
- ensure AST refactor rewrites functions to return their results
- surface transform errors in MCP tooling and add coverage

## Changes
- add `libcst` transformer that appends a return of the last assignment
- handle transform failures in `refactor_to_result`
- test the transform and missing-function path

## Verification
- `python -m pre_commit run --all-files`
- `pytest -q tests/mcp_server`
- `pytest -q tests/runtime` *(fails: cannot import BlockParser/breaker)*

## Runtime impact
- none

## Observability
- no changes

## Rollback
- revert commit 783f8b7


------
https://chatgpt.com/codex/tasks/task_e_68ac327379a0832898bb043b35bdd4c7