### PR TITLE
mcp_server: implement string_info tool

### DIFF
--- a/mcp_server/src/mcp_server/tools/mynewtool.py
+++ b/mcp_server/src/mcp_server/tools/mynewtool.py
@@ -1,3 +1,5 @@
+"""Simple MCP tool providing basic string statistics."""
+
 from __future__ import annotations
 
 from typing import Any
@@ -6,16 +8,22 @@ from mcp_server.server import app
 
 
 @app.tool(
-    name="MyNewTool",
-    description="Describe what MyNewTool does, required args, and return shape.",
+    name="string_info",
+    description="Return uppercase variant and length for a non-empty string.",
 )
-async def MyNewTool(example_arg: str) -> dict[str, Any]:
-    """Short doc for humans & LLM.
+async def MyNewTool(text: str) -> dict[str, Any]:
+    """Compute basic information about ``text``.
+
     Args:
-        example_arg: what it is.
+        text: Non-empty string to analyze.
 
     Returns:
-        dict with structured result for the client.
+        A mapping with the original string, an uppercase version, and its length.
+        If validation fails, the mapping contains an ``error`` message instead.
     """
-    # TODO: implement. Keep scope narrow. Validate inputs.
-    return {"ok": True, "arg": example_arg}
+    if not isinstance(text, str):
+        return {"error": "text must be a string"}
+    if not text.strip():
+        return {"error": "text must be a non-empty string"}
+    return {"original": text, "upper": text.upper(), "length": len(text)}
+

--- a/tests/mcp_server/test_mynewtool.py
+++ b/tests/mcp_server/test_mynewtool.py
@@ -1,0 +1,28 @@
+"""Tests for the simple string_info MCP tool."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "mcp_server" / "src"))
+
+from mcp_server.tools.mynewtool import MyNewTool
+
+
+@pytest.mark.asyncio
+async def test_mynewtool_success() -> None:
+    result = await MyNewTool("hello")
+    assert result == {"original": "hello", "upper": "HELLO", "length": 5}
+
+
+@pytest.mark.asyncio
+async def test_mynewtool_validation() -> None:
+    result_empty = await MyNewTool("")
+    assert result_empty["error"] == "text must be a non-empty string"
+
+    result_type = await MyNewTool(123)  # type: ignore[arg-type]
+    assert result_type["error"] == "text must be a string"
+


### PR DESCRIPTION
### Summary
- add `string_info` MCP tool to return uppercase text and length with input validation
- cover tool behavior with unit tests

### Changes
- replace placeholder implementation with usable `string_info` tool
- create `tests/mcp_server/test_mynewtool.py`

### Verification
- `pre-commit run --all-files`
- `pytest tests/mcp_server/test_mynewtool.py -q`
- `pytest -q tests/runtime` *(fails: ImportError for BlockParser and breaker)*

### Runtime impact
- none, simple string manipulation

### Observability
- no changes

### Rollback
- revert commits


------
https://chatgpt.com/codex/tasks/task_e_68ac3274b9c083288636e7e1f3807b55