### PR TITLE
perplexica: add config toggles and offline telemetry

### DIFF
--- a/src/config/perplexica.yaml
+++ b/src/config/perplexica.yaml
@@ -6,6 +6,14 @@ perplexica:
   safe: true
   time_range_default: all
 
+  defaults:
+    cache_enabled: true
+    rerank_enabled: true
+
+  web_agent:
+    search_url: "http://localhost:3333/search"
+    health_url: "http://localhost:3333/health"
+
   provider_order:
     web: [serpapi, bing, google_cse]
     news: [gnews, serpapi]

--- a/tests/runtime/test_event_telemetry.py
+++ b/tests/runtime/test_event_telemetry.py
@@ -71,3 +71,25 @@ async def test_plugin_events_include_telemetry_fields() -> None:
     assert result_evt.conversation_id == "session_b"
     assert result_evt.correlation_id
     assert isinstance(result_evt.timestamp, datetime)
+
+
+@pytest.mark.asyncio
+async def test_perplexica_offline_emits_error_event() -> None:
+    bus = CaptureBus()
+    perplex = PerplexicaSearchPlugin()
+    await perplex.setup(bus, None, {})
+    perplex.web_agent = None
+    perplex.web_agent_search_url = "http://localhost:9/search"
+
+    search_event = create_event(
+        "perplexica_search",
+        query="hi",
+        session_id="session_c",
+        conversation_id="session_c",
+        source_plugin="client",
+    )
+    await perplex._handle_search_request(search_event)
+    error_evt = next(e for e in bus.events if e.event_type == "tool_result")
+    assert not error_evt.success
+    assert error_evt.source_plugin == "perplexica_search"
+    assert "WebAgent unavailable" in error_evt.error


### PR DESCRIPTION
## Summary
- add cache/rerank defaults and web agent endpoints to Perplexica config
- read new settings in PerplexicaSearchPlugin and log when WebAgent is unavailable
- add runtime telemetry tests for Perplexica offline scenario

## Testing
- `pre-commit run --all-files`
- `pytest tests/runtime/test_event_telemetry.py::test_plugin_events_include_telemetry_fields -q`
- `pytest tests/runtime/test_event_telemetry.py::test_perplexica_offline_emits_error_event -q`
- `pytest -q tests/runtime` *(fails: Multiple existing tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_68ac5307a5948328a13b1cf9ea454dec