### PR TITLE
deepcode: emit multi-file outputs

### DIFF
--- a/docs/PUTER_INTEGRATION.md
+++ b/docs/PUTER_INTEGRATION.md
@@ -11,6 +11,13 @@ The Puter integration provides seamless cloud file storage, process execution, a
 - **Neural Atoms**: Deterministic UUID generation for cognitive fabric integration
 - **Comprehensive Tests**: Full test suite with 18+ test cases
 
+## DeepCode Workflow
+
+DeepCode orchestrates multi-phase code generation and produces code, test, and documentation artifacts. The `DeepCodePuterBridgePlugin`
+listens for `deepcode_ready_for_apply` and forwards each artifact as a `puter_file_write` event. The `PuterPlugin` then persists
+these files to the cloud workspace and records each write in `operation_history`, ensuring artifacts are immediately available and
+auditable in Puter storage.
+
 ## Features
 
 ### Core Plugin Capabilities

--- a/src/plugins/deepcode_orchestrator_plugin.py
+++ b/src/plugins/deepcode_orchestrator_plugin.py
@@ -37,16 +37,42 @@ class _StubDeepCodeClient(DeepCodeClientInterface):
     async def generate_code(self, plan: Dict[str, Any], references: Dict[str, Any]) -> Dict[str, Any]:
         return {
             "proposal_id": None,
-            "diffs": [{
-                "path": "docs/deepcode_result.md",
-                "change_type": "add",
-                "unified_diff": "--- /dev/null\n+++ b/docs/deepcode_result.md\n@@\n+# Result\n+Hello DeepCode\n",
-                "new_content": "# Result\n\nHello DeepCode\n",
-                "confidence": 0.84
-            }],
-            "tests": [{"path": "tests/test_deepcode_result.py", "content": "def test_ok(): assert True"}],
-            "docs": [{"path": "docs/plan.json", "content": json.dumps(plan)}],
-            "confidence": 0.84
+            "diffs": [
+                {
+                    "path": "docs/deepcode_result.md",
+                    "change_type": "add",
+                    "unified_diff": "--- /dev/null\n+++ b/docs/deepcode_result.md\n@@\n+# Result\n+Hello DeepCode\n",
+                    "new_content": "# Result\n\nHello DeepCode\n",
+                    "confidence": 0.84,
+                },
+                {
+                    "path": "src/new_dir/deepcode_module.py",
+                    "change_type": "add",
+                    "unified_diff": (
+                        "--- /dev/null\n+++ b/src/new_dir/deepcode_module.py\n@@\n+def greet():\n+    return 'deepcode'\n"
+                    ),
+                    "new_content": "def greet():\n    return \"deepcode\"\n",
+                    "confidence": 0.83,
+                },
+            ],
+            "tests": [
+                {"path": "tests/test_deepcode_result.py", "content": "def test_ok(): assert True"},
+                {
+                    "path": "tests/new_dir/test_deepcode_module.py",
+                    "content": (
+                        "from src.new_dir.deepcode_module import greet\n\n"
+                        "def test_greet():\n    assert greet() == \"deepcode\""
+                    ),
+                },
+            ],
+            "docs": [
+                {"path": "docs/plan.json", "content": json.dumps(plan)},
+                {
+                    "path": "docs/new_dir/summary.md",
+                    "content": "# Summary\nGenerated module\n",
+                },
+            ],
+            "confidence": 0.84,
         }
     async def validate(self, implementation: Dict[str, Any]) -> Dict[str, Any]:
         return {"status": "pass", "lint_errors": 0, "tests_passed": True, "confidence": 0.91}


### PR DESCRIPTION
## Summary
- extend stub DeepCode client to emit multiple code, test, and doc artifacts across directories
- ensure DeepCode orchestration writes mirrored Puter operations tracked in plugin history
- document DeepCode to Puter workflow producing cloud-synced artifacts

## Changes
- broaden `_StubDeepCodeClient.generate_code` outputs
- add Puter file-write assertions and event re-emission in `test_deepcode_orchestrator`
- describe DeepCode workflow in `PUTER_INTEGRATION.md`

## Verification
- `python -m pre_commit run --all-files`
- `pytest -q tests/runtime/test_deepcode_orchestrator.py`
- `pytest -q tests/runtime` *(fails: test suite reports multiple pre-existing failures)*

## Runtime impact
- stub client now emits more artifacts; no production path change.

## Observability
- Puter file writes surfaced in `operation_history` for traceability.

## Rollback
- revert commit 8c27485.


------
https://chatgpt.com/codex/tasks/task_e_68ac5309e8d48328911dc235a09faf66