### PR TITLE
plugins: use register for memory atoms

### DIFF
--- a/src/plugins/brainstorm_plugin.py
+++ b/src/plugins/brainstorm_plugin.py
@@ -345,25 +345,17 @@ Make the code practical and executable. Focus on filling genuine capability gaps
                 )
             else:
                 # Fallback: create neural atom directly
-                from src.core.neural_atom import NeuralAtom
+                import json
+                from src.core.neural_atom import NeuralAtomMetadata, TextualMemoryAtom
 
-                # Generate embedding for searchability
-                if hasattr(self.store, "embed_text"):
-                    embedding_text = f"{atom.tool} {atom.description} {atom.code[:100]}"
-                    embeddings = await self.store.embed_text([embedding_text])
-                    vector = (
-                        embeddings[0]
-                        if embeddings
-                        else np.random.rand(EMBEDDING_DIM).astype(np.float32)
-                    )
-                else:
-                    vector = np.random.rand(1024).astype(np.float32)
-
-                neural_atom = NeuralAtom(
-                    key=memory_id, default_value=atom.model_dump(), vector=vector
+                metadata = NeuralAtomMetadata(
+                    name=memory_id,
+                    description=atom.description,
+                    capabilities=[atom.tool],
                 )
+                neural_atom = TextualMemoryAtom(metadata, json.dumps(atom.model_dump()))
 
-                self.store.add(neural_atom)
+                self.store.register(neural_atom)
                 logger.info(f"Stored atom {memory_id} directly in neural store")
 
         except Exception as e:

--- a/src/plugins/compose_plugin.py
+++ b/src/plugins/compose_plugin.py
@@ -457,6 +457,7 @@ Do not include explanations or markdown formatting."""
         except Exception as e:
             logger.error(f"Error executing composed tool: {e}")
 
+
     async def _store_atom(self, memory_id: str, atom: DynamicAtom) -> None:
         """Store composed atom in semantic memory"""
         try:
@@ -468,32 +469,23 @@ Do not include explanations or markdown formatting."""
                 )
             else:
                 # Fallback: create neural atom directly
-                from src.core.neural_atom import NeuralAtom
+                import json
+                from src.core.neural_atom import NeuralAtomMetadata, TextualMemoryAtom
 
-                # Generate embedding for searchability
-                if hasattr(self.store, "embed_text"):
-                    embedding_text = f"{atom.tool} {atom.description} {atom.code[:100]}"
-                    embeddings = await self.store.embed_text([embedding_text])
-                    vector = (
-                        embeddings[0]
-                        if embeddings
-                        else np.random.rand(EMBEDDING_DIM).astype(np.float32)
-                    )
-                else:
-                    vector = np.random.rand(1024).astype(np.float32)
-
-                neural_atom = NeuralAtom(
-                    key=memory_id, default_value=atom.model_dump(), vector=vector
+                metadata = NeuralAtomMetadata(
+                    name=memory_id,
+                    description=atom.description,
+                    capabilities=[atom.tool],
                 )
+                neural_atom = TextualMemoryAtom(metadata, json.dumps(atom.model_dump()))
 
-                self.store.add(neural_atom)
+                self.store.register(neural_atom)
                 logger.info(
-                    f"Stored composed atom {memory_id} directly in neural store"
+                    f"Stored composed atom {memory_id} directly in neural store",
                 )
-
         except Exception as e:
             logger.error(f"Failed to store composed atom {memory_id}: {e}")
-
+    
     async def _call_gemini_async(self, prompt: str) -> str:
         """Async wrapper for Gemini API call"""
         loop = asyncio.get_event_loop()
@@ -501,7 +493,7 @@ Do not include explanations or markdown formatting."""
             None, lambda: self.llm_client.generate_content(prompt)
         )
         return response.text
-
+    
     async def get_stats(self) -> dict[str, Any]:
         """Get composition statistics"""
         return {

--- a/tests/runtime/test_plugin_store_registration.py
+++ b/tests/runtime/test_plugin_store_registration.py
@@ -1,0 +1,36 @@
+import numpy as np
+import pytest
+
+from src.plugins.brainstorm_plugin import BrainstormPlugin, DynamicAtom as BrainstormAtom
+from src.plugins.compose_plugin import ComposePlugin, DynamicAtom as ComposeAtom
+
+
+class MockStore:
+    def __init__(self):
+        self.registered = []
+
+    async def embed_text(self, texts: list[str]):
+        return [np.zeros(1024, dtype=np.float32) for _ in texts]
+
+    def register(self, atom):
+        self.registered.append(atom)
+
+
+@pytest.mark.asyncio
+async def test_brainstorm_registers_memory_atom():
+    store = MockStore()
+    plugin = BrainstormPlugin()
+    plugin.store = store
+    atom = BrainstormAtom(tool="t", code="print('hi')", description="d")
+    await plugin._store_atom("mem1", atom)
+    assert store.registered and store.registered[0].key == "mem1"
+
+
+@pytest.mark.asyncio
+async def test_compose_registers_memory_atom():
+    store = MockStore()
+    plugin = ComposePlugin()
+    plugin.store = store
+    atom = ComposeAtom(tool="t", code="print('hi')", description="d")
+    await plugin._store_atom("mem2", atom)
+    assert store.registered and store.registered[0].key == "mem2"


### PR DESCRIPTION
## Summary
- replace direct NeuralStore adds with register using TextualMemoryAtom
- test Brainstorm and Compose plugins fallback registration

## Changes
- use `NeuralAtomMetadata` and `TextualMemoryAtom` when persisting new atoms
- call `NeuralStore.register` instead of deprecated methods
- cover registration paths with focused unit tests

## Verification
- `pre-commit run --all-files`
- `pytest -q tests/runtime/test_plugin_store_registration.py`
- `pytest -q tests/runtime` *(fails: docstring missing, contract cache, router flow, logging, broadcaster, dynamic tool, timeouts, result capping, retry, schema bypass, smoke, telemetry, plugin startup, user input tool)*

## Runtime impact
- no change to runtime latency limits or retry behavior
- uses existing registration APIs without altering execution flow

## Observability
- no new telemetry fields or event shapes; reuse existing logging

## Rollback
- revert the commits to restore previous memory atom storage behavior

------
https://chatgpt.com/codex/tasks/task_e_68ac5f0a51108328b680aec3db970f0c