### PR TITLE
plugins: decouple event bus init

### DIFF
--- a/src/plugins/autonomy_tracker.py
+++ b/src/plugins/autonomy_tracker.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass
 from typing import Any, Dict, List
 
 from src.core.plugin_interface import PluginInterface
-from src.core.event_bus import EventBus
 from src.core.events import create_event
 
 
@@ -22,8 +21,7 @@ class AutonomyMetrics:
 
 
 class AutonomyTracker(PluginInterface):
-    def __init__(self, event_bus: EventBus):
-        self.event_bus = event_bus
+    def __init__(self):
         self.metrics_history: List[AutonomyMetrics] = []
 
     @property
@@ -31,9 +29,7 @@ class AutonomyTracker(PluginInterface):
         return "autonomy_tracker"
 
     async def setup(self, event_bus: Any, store: Any, config: Dict[str, Any]) -> None:  # type: ignore[override]
-        self.event_bus = event_bus
-        self.store = store
-        self.config = config
+        await super().setup(event_bus, store, config)
 
     async def start(self) -> None:  # type: ignore[override]
         self.is_running = True

--- a/tests/runtime/test_oak_core_plugins.py
+++ b/tests/runtime/test_oak_core_plugins.py
@@ -1,0 +1,53 @@
+from typing import Any
+
+import pytest
+
+from src.plugins.autonomy_tracker import AutonomyTracker
+from src.plugins.knowledge_gap_detector import KnowledgeGapDetector
+from src.plugins.cortex_adapter_plugin import CortexAdapterPlugin
+
+
+class DummyEventBus:
+    def __init__(self) -> None:
+        self.published: list[Any] = []
+        self.subscriptions: list[tuple[str, Any]] = []
+
+    async def publish(self, event: Any) -> None:  # pragma: no cover - simple stub
+        self.published.append(event)
+
+    async def subscribe(self, event_type: str, handler: Any) -> None:
+        self.subscriptions.append((event_type, handler))
+
+
+@pytest.mark.asyncio
+async def test_autonomy_tracker_setup_sets_event_bus() -> None:
+    bus = DummyEventBus()
+    plugin = AutonomyTracker()
+    await plugin.setup(bus, store={}, config={})
+    assert plugin.event_bus is bus
+
+
+@pytest.mark.asyncio
+async def test_knowledge_gap_detector_setup_subscribes() -> None:
+    bus = DummyEventBus()
+    plugin = KnowledgeGapDetector()
+    await plugin.setup(bus, store={}, config={})
+    assert plugin.event_bus is bus
+    assert {e for e, _ in bus.subscriptions} == {
+        "reasoning_complete",
+        "navigation_complete",
+        "conversation_turn",
+    }
+
+
+@pytest.mark.asyncio
+async def test_cortex_adapter_plugin_setup_subscribes_and_sets_deps() -> None:
+    bus = DummyEventBus()
+    graph = object()
+    navigator = object()
+    plugin = CortexAdapterPlugin()
+    await plugin.setup(bus, store={}, config={"graph": graph, "navigator": navigator})
+    assert plugin.event_bus is bus
+    assert plugin.graph is graph
+    assert plugin.navigator is navigator
+    assert {e for e, _ in bus.subscriptions} == {"reasoning_request", "knowledge_gap"}


### PR DESCRIPTION
## Summary
- decouple event bus injection from plugin constructors
- add tests for oak_core plugin setup

## Testing
- `pre-commit run --all-files`
- `pytest tests/runtime/test_oak_core_plugins.py`
- `pytest -q tests/runtime` *(fails: AssertionError: |---:|----|....)*

------
https://chatgpt.com/codex/tasks/task_e_68ac5f0213f88328bc3253e7b494ea4e