### PR TITLE
deps: add CPU torch and expand GPU install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,10 @@ cp .env.example .env  # then set at least one provider key or local model config
 Using Make (includes lint targets):
 
 ```bash
-make deps
+make deps               # CPU defaults, includes torch CPU build
+# For GPU acceleration:
+# pip install --index-url https://download.pytorch.org/whl/cu121 torch
+# pip install -r requirements-gpu.txt
 make lint  # optional
 ```
 
@@ -48,6 +51,10 @@ Or manually:
 python -m venv .venv
 ./.venv/Scripts/Activate.ps1  # Windows PowerShell
 pip install -e .
+# GPU extras (optional):
+# pip install --index-url https://download.pytorch.org/whl/cu121 torch
+# pip install -r requirements-gpu.txt
+# The above replaces the CPU build installed by default
 ```
 
 ### 3. Run the development server

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -25,8 +25,10 @@
 2. **Install & run**
 
    ```bash
-   make deps               # install runtime + test deps (CPU only)
-   # For GPU acceleration, install extras: pip install -r requirements-gpu.txt (optional)
+   make deps               # install runtime + test deps (CPU torch build)
+   # For GPU acceleration:
+   # pip install --index-url https://download.pytorch.org/whl/cu121 torch
+   # pip install -r requirements-gpu.txt
    make lint               # run pre-commit hooks
    pre-commit run --all-files
    make test               # run runtime suite (target ≥70% coverage)
@@ -73,7 +75,7 @@ Steps:
 1) Environment
    - create .env from .env.example if missing; ensure PYTHONPATH=./src is set.
    - append GEMINI_API_KEY or OPENAI_API_KEY or ANTHROPIC_API_KEY if present.
-   - install deps: make deps  # skip GPU extras unless needed
+   - install deps: make deps  # CPU torch build; for GPU: pip install --index-url https://download.pytorch.org/whl/cu121 torch && pip install -r requirements-gpu.txt
    - run pre-commit on touched files: make lint
 2) Sanity checks
    - python -m pip show fastapi uvicorn

--- a/requirements-gpu.txt
+++ b/requirements-gpu.txt
@@ -1,6 +1,5 @@
 -r requirements.txt
 
-# GPU dependencies
-torch
+# GPU dependencies (install GPU torch wheel separately if needed)
 nvidia-cuda-runtime-cu12
 nvidia-cudnn-cu12

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ openai-agents>=0.1
 # ML and evolution
 scikit-learn>=1.3.0
 scipy>=1.10.0
+torch>=2.2.0  # CPU build; GPU extras in requirements-gpu.txt
 
 # Graph export
 # python-graphml>=1.0  # optional, install manually if available

--- a/tests/runtime/test_imports.py
+++ b/tests/runtime/test_imports.py
@@ -1,7 +1,10 @@
 import fastapi
 import networkx as nx
+import torch
 
 
-def test_fastapi_and_networkx_importable():
+def test_core_imports():
     assert fastapi.__version__
     assert nx.__version__
+    assert torch.__version__
+    assert not torch.cuda.is_available()


### PR DESCRIPTION
## Summary
- add torch>=2.2.0 to core requirements for CPU installs
- document CPU vs GPU install paths and GPU wheel instructions
- verify torch import via runtime tests

## Changes
- add CPU torch dependency in `requirements.txt`
- clarify GPU extras in README and `docs/runtime.md`
- streamline `requirements-gpu.txt` comments
- expand import test to ensure torch loads on CPU

## Verification
- `pre-commit run --files README.md docs/runtime.md requirements-gpu.txt tests/runtime/test_imports.py requirements.txt` (skipped)
- `pytest -q tests/runtime` *(fails: multiple runtime tests require additional setup)*

## Runtime impact
- none

## Observability
- no new events or metrics

## Rollback
- revert these commits

------
https://chatgpt.com/codex/tasks/task_e_68ac5fccc81c8328b167e5bd1dd0810a