### PR TITLE
oak_core: configurable PPO epochs

### DIFF
--- a/tests/runtime/test_option_trainer_ppo_epochs.py
+++ b/tests/runtime/test_option_trainer_ppo_epochs.py
@@ -1,0 +1,80 @@
+import importlib.util
+from pathlib import Path
+import sys
+
+import pytest
+import torch
+
+spec = importlib.util.spec_from_file_location(
+    "option_trainer", Path("src/plugins/oak_core/option_trainer.py")
+)
+option_trainer = importlib.util.module_from_spec(spec)
+sys.modules["option_trainer"] = option_trainer
+assert spec.loader is not None
+spec.loader.exec_module(option_trainer)
+OptionTrainer = option_trainer.OptionTrainer
+
+
+class Bus:
+    def __init__(self) -> None:
+        self.events: list[dict] = []
+
+    async def emit(self, event_type: str, **kwargs) -> None:
+        self.events.append({"event_type": event_type, **kwargs})
+
+    async def subscribe(self, event_type, handler) -> None:  # pragma: no cover
+        pass
+
+
+class _TestOptionTrainer(OptionTrainer):
+    async def start(self) -> None:  # pragma: no cover
+        pass
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("ppo_epochs,expected_steps", [(1, 2), (3, 6)])
+async def test_ppo_epochs_controls_iterations(ppo_epochs: int, expected_steps: int) -> None:
+    bus = Bus()
+    trainer = _TestOptionTrainer()
+    await trainer.setup(
+        bus,
+        None,
+        {"state_dim": 2, "action_dim": 2, "batch_size": 2, "ppo_epochs": ppo_epochs},
+    )
+
+    class SubEvent:
+        subproblem_id = "1"
+
+    await trainer.handle_subproblem_defined(SubEvent())
+    opt_id = "option_1"
+
+    net = trainer.options[opt_id]
+    for p in net.parameters():
+        torch.nn.init.constant_(p, 0.0)
+
+    for i in range(4):
+        class StepEvent:
+            pass
+
+        e = StepEvent()
+        e.option_id = opt_id
+        e.state = [0.0, 0.0]
+        e.action = 0
+        e.reward = 1.0
+        e.next_state = [0.0, 0.0]
+        e.done = i == 3
+        await trainer.handle_state_transition(e)
+
+    steps = 0
+    orig_step = trainer.optim[opt_id].step
+
+    def step_hook(*args, **kwargs):
+        nonlocal steps
+        steps += 1
+        return orig_step(*args, **kwargs)
+
+    trainer.optim[opt_id].step = step_hook  # type: ignore[assignment]
+
+    await trainer.handle_training_tick(object())
+
+    assert steps == expected_steps


### PR DESCRIPTION
## Summary
- allow OptionTrainer PPO loop to run for a configurable number of epochs
- expose `ppo_epochs` in plugin configuration and document default
- test that PPO epochs setting controls optimizer step count

## Testing
- `pre-commit run --all-files`
- `pytest -q tests/runtime/test_option_trainer_ppo_epochs.py`
- `pytest -q tests/runtime` *(fails: AssertionError in tests/runtime/test_agents_md_integrity.py::test_plugin_table_integrity, aiohttp.client_exceptions.ClientConnectorError in tests/runtime/test_deepcode_orchestrator.py::test_deepcode_diffs_mirrored_to_puter, AssertionError: execute_turn missing docstring in tests/runtime/test_docstrings.py::test_router_execute_turn_docstring, assert 0 == 1 in tests/runtime/test_dynamic_contract_cache.py::test_contract_cached_and_reused, ValueError: 'AbilityCalled' is not in list in tests/runtime/test_execute_turn_stream.py::test_execute_turn_stream_normal_flow, assert False in tests/runtime/test_execute_turn_stream.py::test_execute_turn_stream_early_final_answer, assert False in tests/runtime/test_logging_events_replacement.py::test_core_utils_plugin_discovers_and_logs, assert False in tests/runtime/test_logging_events_replacement.py::test_sync_once_main_logs, assert False in tests/runtime/test_logging_events_replacement.py::test_todo_sync_logging, TypeError: MCPTelemetryBroadcaster.__init__() got an unexpected keyword argument 'broadcast_url' in tests/runtime/test_mcp_broadcaster.py::test_broadcaster_posts_events, AssertionError in tests/runtime/test_router_dynamic_tool.py::test_dynamic_registration_flow, TimeoutError: model stalled in tests/runtime/test_router_model_stream_timeout.py::test_model_stream_timeout, assert '_artifact' in '<tool_call>{"tool":"big","args":...' in tests/runtime/test_router_result_cap.py::test_result_capping, assert 'ok after retry' in '<tool_call>{"tool":"slow_echo"...' in tests/runtime/test_router_retry.py::test_timeout_then_retry, assert False in tests/runtime/test_router_schema_bypass.py::test_schema_bypass, AssertionError: assert 'TaskStarted' in set() in tests/runtime/test_router_smoke.py::test_streaming_single_turn_smoke, AssertionError in tests/runtime/test_telemetry_events.py::test_success_turn_emits_required_fields, AssertionError in tests/runtime/test_telemetry_events.py::test_failing_turn_emits_required_fields, aiohttp.client_exceptions.ClientConnectorError in tests/runtime/test_unified_plugin_startup.py::test_unified_plugins_start_and_pipeline, KeyError: 'response' in tests/runtime/test_user_input_tool.py::test_user_input_tool)*

## Runtime impact
- Configurable PPO epochs may increase training iterations when set above default

## Observability
- No changes to emitted event shapes; existing telemetry preserved

## Rollback
- Revert this PR to restore previous single-epoch PPO behavior


------
https://chatgpt.com/codex/tasks/task_e_68ac6a1cd89c8328bb5bcfbada74f151