### PR TITLE
[oak_core] guard global feature updates

### DIFF
--- a/src/plugins/oak_core/curation_manager.py
+++ b/src/plugins/oak_core/curation_manager.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
-
+import logging
 import re
 from collections import defaultdict
 from typing import Any, Dict
 
 from src.core.plugin_interface import PluginInterface
+
+
+logger = logging.getLogger(__name__)
 
 
 class CurationManager(PluginInterface):
@@ -33,12 +36,70 @@ class CurationManager(PluginInterface):
             "syntactic_error_penalty": -0.1,
         }
         self.error_counts: Dict[str, int] = defaultdict(int)
+        self._required_features = {"global_play", "global_planning"}
 
     async def setup(self, event_bus: Any, store: Any, config: dict[str, Any]) -> None:  # type: ignore[override]
         await super().setup(event_bus, store, config)
         self.cfg.update(config or {})
         await self.subscribe("tool_result", self.handle_tool_result)
         await self.subscribe("oak.prediction_error", self.handle_prediction_error)
+        await self._ensure_global_features()
+
+    async def start(self) -> None:  # type: ignore[override]
+        await super().start()
+
+    async def _ensure_global_features(self) -> None:
+        """Ensure required global features exist in the shared store."""
+        if not self.store:
+            return
+        for fid in self._required_features:
+            if self._feature_exists(fid):
+                continue
+            created = False
+            try:
+                if hasattr(self.store, "create_feature"):
+                    self.store.create_feature(fid)  # type: ignore[attr-defined]
+                    created = True
+                elif hasattr(self.store, "features"):
+                    self.store.features[fid] = {}  # type: ignore[index]
+                    created = True
+            except Exception:  # pragma: no cover - defensive
+                created = False
+            if not created:
+                logger.warning(
+                    "CurationManager missing feature %s and could not create it", fid
+                )
+
+    def _feature_exists(self, feature_id: str) -> bool:
+        if not self.store:
+            return False
+        try:
+            if hasattr(self.store, "has_feature"):
+                return bool(self.store.has_feature(feature_id))  # type: ignore[attr-defined]
+            if hasattr(self.store, "get_feature"):
+                return self.store.get_feature(feature_id) is not None  # type: ignore[attr-defined]
+            if hasattr(self.store, "features"):
+                return feature_id in self.store.features  # type: ignore[attr-defined]
+        except Exception:  # pragma: no cover - defensive
+            return False
+        return False
+
+    async def _emit_utility_update(
+        self, feature_id: str, signal_type: str, value: float, components: dict[str, float]
+    ) -> None:
+        if not self._feature_exists(feature_id):
+            logger.warning(
+                "CurationManager skipping utility update for missing feature '%s'",
+                feature_id,
+            )
+            return
+        await self.emit_event(
+            "oak.feature_utility_update",
+            feature_id=feature_id,
+            signal_type=signal_type,
+            value=value,
+            components=components,
+        )
 
     async def handle_tool_result(self, event: Any) -> None:
         success = bool(getattr(event, "success", False))
@@ -62,33 +123,21 @@ class CurationManager(PluginInterface):
                 error=str(error_msg)[:256],
             )
             # Global planning utility nudge (no specific feature_id attached)
-            await self.emit_event(
-                "oak.feature_utility_update",
-                feature_id="global_planning",
-                signal_type="planning",
-                value=signal,
-                components={"planning": signal},
+            await self._emit_utility_update(
+                "global_planning", "planning", signal, {"planning": signal}
             )
         else:
             # Positive play signal on successful tool usage
             signal = float(self.cfg["play_weight"])
-            await self.emit_event(
-                "oak.feature_utility_update",
-                feature_id="global_play",
-                signal_type="play",
-                value=signal,
-                components={"play": signal},
+            await self._emit_utility_update(
+                "global_play", "play", signal, {"play": signal}
             )
 
     async def handle_prediction_error(self, event: Any) -> None:
         # Route prediction confidence as a positive signal for planning utility
         err = float(getattr(event, "error", 0.0))
         signal = 1.0 / (1.0 + err)
-        await self.emit_event(
-            "oak.feature_utility_update",
-            feature_id="global_planning",
-            signal_type="planning",
-            value=signal,
-            components={"planning": signal},
+        await self._emit_utility_update(
+            "global_planning", "planning", signal, {"planning": signal}
         )
 

--- a/tests/runtime/test_curation_manager_features.py
+++ b/tests/runtime/test_curation_manager_features.py
@@ -1,0 +1,68 @@
+import importlib.util
+import pathlib
+
+import pytest
+
+spec = importlib.util.spec_from_file_location(
+    "curation_manager", pathlib.Path("src/plugins/oak_core/curation_manager.py")
+)
+curation_manager = importlib.util.module_from_spec(spec)
+assert spec.loader
+spec.loader.exec_module(curation_manager)
+CurationManager = curation_manager.CurationManager
+
+
+class DummyEventBus:
+    def __init__(self) -> None:
+        self.published = []
+        self.subscriptions = []
+
+    async def publish(self, event):
+        self.published.append(event)
+
+    async def subscribe(self, event_type, handler):
+        self.subscriptions.append((event_type, handler))
+
+
+class FeatureStore:
+    def __init__(self) -> None:
+        self.features = {}
+
+    def create_feature(self, fid: str) -> None:
+        self.features[fid] = {}
+
+
+@pytest.mark.asyncio
+async def test_curation_manager_emits_when_features_present():
+    bus = DummyEventBus()
+    store = FeatureStore()
+    plugin = CurationManager()
+    await plugin.setup(bus, store, {})
+    # Features should be initialized
+    assert {"global_play", "global_planning"} <= set(store.features)
+
+    event = type("E", (), {"success": True})()
+    await plugin.handle_tool_result(event)
+    assert any(
+        e.event_type == "oak.feature_utility_update" and e.feature_id == "global_play"
+        for e in bus.published
+    )
+
+
+@pytest.mark.asyncio
+async def test_curation_manager_skips_when_features_missing(caplog):
+    bus = DummyEventBus()
+
+    class BareStore:
+        pass
+
+    store = BareStore()
+    plugin = CurationManager()
+    await plugin.setup(bus, store, {})
+    caplog.set_level("WARNING")
+
+    event = type("E", (), {"success": True})()
+    await plugin.handle_tool_result(event)
+
+    assert not any(e.event_type == "oak.feature_utility_update" for e in bus.published)
+    assert any("skipping utility update" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- ensure curation manager initializes `global_play` and `global_planning` features
- warn and skip utility updates when required features are missing
- add tests for presence/absence of global features

## Testing
- `make deps`
- `pre-commit run --all-files`
- `pytest -q tests/runtime` *(fails: missing upstream dependencies)*
- `pytest -q tests/runtime/test_curation_manager_features.py tests/runtime/test_oak_core_plugins.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac6a1fe12c8328bec422cd3ade2096