### PR TITLE
[plugins] use oak-prefixed emit_event

### DIFF
--- a/src/plugins/autonomy_tracker.py
+++ b/src/plugins/autonomy_tracker.py
@@ -1,12 +1,10 @@
 from __future__ import annotations
-
 """Track agent autonomy and emit progress events."""
 
 from dataclasses import dataclass
 from typing import Any, Dict, List
 
 from src.core.plugin_interface import PluginInterface
-from src.core.events import create_event
 
 
 @dataclass
@@ -37,16 +35,14 @@ class AutonomyTracker(PluginInterface):
     async def record_metrics(self, tasks_completed: int, assistance_requests: int) -> None:
         metrics = AutonomyMetrics(tasks_completed, assistance_requests)
         self.metrics_history.append(metrics)
-        await self.event_bus.publish(
-            create_event(
-                "autonomy_update",
-                event_version=1,
-                source_plugin=self.name,
-                current_score=metrics.autonomy_score(),
-                cortex_dependency=assistance_requests,
-                trend="flat",
-                milestone_reached=False,
-            )
+        await self.emit_event(
+            "oak.autonomy_update",
+            event_version=1,
+            source_plugin=self.name,
+            current_score=metrics.autonomy_score(),
+            cortex_dependency=assistance_requests,
+            trend="flat",
+            milestone_reached=False,
         )
 
     async def get_graduation_readiness(self) -> Dict[str, Any]:

--- a/src/plugins/knowledge_gap_detector.py
+++ b/src/plugins/knowledge_gap_detector.py
@@ -5,7 +5,6 @@ from typing import Any, Dict, List, Protocol
 import uuid
 
 from src.core.plugin_interface import PluginInterface
-from src.core.events import create_event
 from src.core.utils import CooldownLRU
 
 
@@ -94,13 +93,11 @@ class KnowledgeGapDetector(PluginInterface):
                 return
         correlation_id = context.get("correlation_id") or str(uuid.uuid4())
         trace_id = context.get("trace_id") or correlation_id
-        await self.event_bus.publish(
-            create_event(
-                "knowledge_gap",
-                event_version=1,
-                source_plugin=self.name,
-                gap_description=gap_description,
-                context={**context, "hop_count": hop_count + 1, "correlation_id": correlation_id, "trace_id": trace_id},
-                gap_type=gap_type,
-            )
+        await self.emit_event(
+            "oak.knowledge_gap",
+            event_version=1,
+            source_plugin=self.name,
+            gap_description=gap_description,
+            context={**context, "hop_count": hop_count + 1, "correlation_id": correlation_id, "trace_id": trace_id},
+            gap_type=gap_type,
         )

--- a/tests/runtime/test_oak_core_plugins.py
+++ b/tests/runtime/test_oak_core_plugins.py
@@ -1,4 +1,5 @@
 from typing import Any
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -51,3 +52,27 @@ async def test_cortex_adapter_plugin_setup_subscribes_and_sets_deps() -> None:
     assert plugin.graph is graph
     assert plugin.navigator is navigator
     assert {e for e, _ in bus.subscriptions} == {"reasoning_request", "knowledge_gap"}
+
+
+@pytest.mark.asyncio
+async def test_autonomy_tracker_emits_oak_prefixed_event() -> None:
+    bus = DummyEventBus()
+    plugin = AutonomyTracker()
+    await plugin.setup(bus, store={}, config={})
+    plugin.emit_event = AsyncMock()
+    await plugin.record_metrics(tasks_completed=5, assistance_requests=1)
+    plugin.emit_event.assert_called_once()
+    args, _ = plugin.emit_event.call_args
+    assert args[0] == "oak.autonomy_update"
+
+
+@pytest.mark.asyncio
+async def test_knowledge_gap_detector_emits_oak_prefixed_event() -> None:
+    bus = DummyEventBus()
+    plugin = KnowledgeGapDetector()
+    await plugin.setup(bus, store={}, config={})
+    plugin.emit_event = AsyncMock()
+    await plugin._maybe_publish_gap(gap_description="desc", context={}, gap_type="test")
+    plugin.emit_event.assert_called_once()
+    args, _ = plugin.emit_event.call_args
+    assert args[0] == "oak.knowledge_gap"


### PR DESCRIPTION
## Summary
- refactor AutonomyTracker and KnowledgeGapDetector to emit events via `emit_event("oak.*")`
- add tests asserting oak-prefixed events from these plugins

## Changes
- replace `create_event` calls with direct `emit_event` in AutonomyTracker and KnowledgeGapDetector
- remove redundant `create_event` imports
- add runtime tests checking for `oak.` prefix in emitted event types

## Verification
- `pre-commit run --all-files`
- `pytest -q tests/runtime` *(fails: network-unreachable for puter.com and other runtime dependencies)*

## Runtime impact
- none expected; uses existing `emit_event` helper which keeps telemetry consistent

## Observability
- Autonomy and knowledge gap events now consistently use `oak.` prefix for downstream telemetry processing

## Rollback
- Revert commit `[plugins] use oak-prefixed emit_event`

------
https://chatgpt.com/codex/tasks/task_e_68ac6a17cde88328b96452138ce676ad