### PR TITLE
[oak_core] streamline setup

### DIFF
--- a/src/plugins/oak_core/coordinator.py
+++ b/src/plugins/oak_core/coordinator.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from src.core.plugin_interface import PluginInterface
+
+from .feature_discovery import FeatureDiscoveryEngine
+from .subproblem_manager import SubproblemManager
+from .option_trainer import OptionTrainer
+from .prediction_engine import PredictionEngine
+from .planning_engine import PlanningEngine
+from .curation_manager import CurationManager
+
+
+class OakCoordinator(PluginInterface):
+    """High level orchestrator wiring together OaK core engines."""
+
+    @property
+    def name(self) -> str:  # type: ignore[override]
+        return "oak_coordinator"
+
+    def __init__(self) -> None:
+        super().__init__()
+        # Instantiate subcomponents without runtime dependencies
+        self.feature_engine = FeatureDiscoveryEngine()
+        self.subproblem_manager = SubproblemManager()
+        self.option_trainer = OptionTrainer()
+        self.prediction_engine = PredictionEngine()
+        self.planning_engine = PlanningEngine(option_source=self.option_trainer)
+        self.curation_manager = CurationManager()
+
+    async def setup(self, event_bus: Any, store: Any, config: Dict[str, Any]) -> None:  # type: ignore[override]
+        await super().setup(event_bus, store, config)
+        cfg = config or {}
+        await self.feature_engine.setup(event_bus, store, cfg.get("feature_discovery", {}))
+        await self.subproblem_manager.setup(event_bus, store, cfg.get("subproblem_manager", {}))
+        await self.option_trainer.setup(event_bus, store, cfg.get("option_trainer", {}))
+        await self.prediction_engine.setup(event_bus, store, cfg.get("prediction_engine", {}))
+        # ensure planning engine sees the trained options
+        self.planning_engine.option_source = self.option_trainer
+        await self.planning_engine.setup(event_bus, store, cfg.get("planning_engine", {}))
+        await self.curation_manager.setup(event_bus, store, cfg.get("curation_manager", {}))
+
+    async def start(self) -> None:  # type: ignore[override]
+        await super().start()
+        for component in (
+            self.feature_engine,
+            self.subproblem_manager,
+            self.option_trainer,
+            self.prediction_engine,
+            self.planning_engine,
+            self.curation_manager,
+        ):
+            if hasattr(component, "start"):
+                await component.start()
+
+    async def shutdown(self) -> None:  # type: ignore[override]
+        for component in (
+            self.feature_engine,
+            self.subproblem_manager,
+            self.option_trainer,
+            self.prediction_engine,
+            self.planning_engine,
+            self.curation_manager,
+        ):
+            if hasattr(component, "shutdown"):
+                await component.shutdown()
+        await super().shutdown()

--- a/src/plugins/oak_core/curation_manager.py
+++ b/src/plugins/oak_core/curation_manager.py
@@ -40,6 +40,12 @@ class CurationManager(PluginInterface):
         await self.subscribe("tool_result", self.handle_tool_result)
         await self.subscribe("oak.prediction_error", self.handle_prediction_error)
 
+    async def start(self) -> None:  # type: ignore[override]
+        await super().start()
+
+    async def shutdown(self) -> None:  # type: ignore[override]
+        await super().shutdown()
+
     async def handle_tool_result(self, event: Any) -> None:
         success = bool(getattr(event, "success", False))
         error_msg = getattr(event, "error", "") or ""

--- a/src/plugins/oak_core/option_trainer.py
+++ b/src/plugins/oak_core/option_trainer.py
@@ -86,6 +86,12 @@ class OptionTrainer(PluginInterface):
         await self.subscribe("oak.state_transition", self.handle_state_transition)
         await self.subscribe("deliberation_tick", self.handle_training_tick)
 
+    async def start(self) -> None:  # type: ignore[override]
+        await super().start()
+
+    async def shutdown(self) -> None:  # type: ignore[override]
+        await super().shutdown()
+
     async def handle_subproblem_defined(self, event: Any) -> None:
         sub_id = getattr(event, "subproblem_id", None)
         if not sub_id:

--- a/src/plugins/oak_core/planning_engine.py
+++ b/src/plugins/oak_core/planning_engine.py
@@ -28,6 +28,12 @@ class PlanningEngine(PluginInterface):
         self.cfg.update(config or {})
         await self.subscribe("goal_received", self.handle_goal)
 
+    async def start(self) -> None:  # type: ignore[override]
+        await super().start()
+
+    async def shutdown(self) -> None:  # type: ignore[override]
+        await super().shutdown()
+
     async def handle_goal(self, event: Any) -> None:
         goal = getattr(event, "goal", "")
         candidates: List[str] = []

--- a/src/plugins/oak_core/prediction_engine.py
+++ b/src/plugins/oak_core/prediction_engine.py
@@ -68,6 +68,12 @@ class PredictionEngine(PluginInterface):
         await self.subscribe("oak.option_created", self.handle_option_created)
         await self.subscribe("oak.state_transition", self.handle_state_transition)
 
+    async def start(self) -> None:  # type: ignore[override]
+        await super().start()
+
+    async def shutdown(self) -> None:  # type: ignore[override]
+        await super().shutdown()
+
     async def handle_option_created(self, event: Any) -> None:
         option_id = getattr(event, "option_id", None)
         if not option_id:

--- a/src/plugins/oak_core/subproblem_manager.py
+++ b/src/plugins/oak_core/subproblem_manager.py
@@ -53,6 +53,12 @@ class SubproblemManager(PluginInterface):
         await self.subscribe("oak.feature_utility_updated", self.handle_feature_utility)
         await self.subscribe("oak.option_completed", self.handle_option_completed)
 
+    async def start(self) -> None:  # type: ignore[override]
+        await super().start()
+
+    async def shutdown(self) -> None:  # type: ignore[override]
+        await super().shutdown()
+
     async def handle_feature_utility(self, event: Any) -> None:
         feature_id = getattr(event, "feature_id", None)
         utility = float(getattr(event, "utility", 0.0))

--- a/tests/plugins/oak_core/test_coordinator.py
+++ b/tests/plugins/oak_core/test_coordinator.py
@@ -1,0 +1,25 @@
+import pytest
+
+from src.plugins.oak_core.coordinator import OakCoordinator
+
+
+class Bus:
+    def __init__(self) -> None:
+        self.subscriptions: list[tuple[str, object]] = []
+
+    async def emit(self, event_type: str, **kwargs) -> None:  # pragma: no cover
+        self.subscriptions.append((event_type, kwargs))
+
+    async def subscribe(self, event_type: str, handler) -> None:
+        self.subscriptions.append((event_type, handler))
+
+
+@pytest.mark.asyncio
+async def test_coordinator_setup_propagates_bus() -> None:
+    bus = Bus()
+    coord = OakCoordinator()
+    await coord.setup(bus, None, {})
+    assert coord.event_bus is bus
+    assert coord.feature_engine.event_bus is bus
+    assert coord.option_trainer.event_bus is bus
+    assert coord.planning_engine.option_source is coord.option_trainer


### PR DESCRIPTION
## Summary
- add OakCoordinator orchestrator wired to per-engine setup
- expose start/shutdown lifecycle on oak core engines
- test coordinator setup wiring

## Changes
- add `coordinator.py` and propagate event bus/store during setup
- implement `start`/`shutdown` stubs on subproblem, option, prediction, planning, and curation engines
- exercise coordinator setup via new test

## Verification
- `pre-commit run --all-files`
- `pytest tests/plugins/oak_core/test_coordinator.py tests/plugins/oak_core/test_option_trainer.py`
- `pytest -q tests/runtime` *(fails: router smoke, telemetry, logging, broadcaster, etc.)*

## Runtime impact
- none: coordinator and engines follow existing plugin contract

## Observability
- no changes to event schemas; coordinator forwards existing telemetry

## Rollback
- revert commit `[oak_core] streamline setup`

------
https://chatgpt.com/codex/tasks/task_e_68ac6a1605348328a181a03ae6025006