### PR TITLE
Add toolforge CLI for dynamic MCP tool generation

### DIFF
--- a/src/agents/__init__.py
+++ b/src/agents/__init__.py
@@ -1,0 +1,1 @@
+"""Agent utilities for managing dynamic tools."""

--- a/src/agents/toolforge.py
+++ b/src/agents/toolforge.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import textwrap
+from pathlib import Path
+from typing import Any
+import sys
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "mcp_server" / "src"))
+from mcp_server.server import load_tools
+
+
+def _sanitize_name(name: str) -> str:
+    """Return a valid Python identifier derived from ``name``."""
+    return re.sub(r"\W|^(?=\d)", "_", name)
+
+
+def forge(spec: dict[str, Any]) -> Path:
+    """Create a tool module from ``spec`` and reload dynamic tools.
+
+    Args:
+        spec: Mapping with ``name``, ``description``, ``input_schema``, and ``code``.
+
+    Returns:
+        Path to the generated module.
+    """
+    tools_dir = ROOT / "mcp_server" / "src" / "mcp_server" / "tools"
+    tools_dir.mkdir(parents=True, exist_ok=True)
+
+    name = str(spec["name"])
+    func_name = _sanitize_name(name)
+    description = str(spec.get("description", ""))
+    schema = spec.get("input_schema", {})
+    if not isinstance(schema, dict):
+        raise TypeError("input_schema must be a mapping of arg names to type strings")
+    code = str(spec.get("code", ""))
+
+    args_sig = ", ".join(f"{arg}: {typ}" for arg, typ in schema.items())
+    body = textwrap.indent(code.strip(), "    ")
+
+    module_content = (
+        "from __future__ import annotations\n\n"
+        "from typing import Any\n"
+        "from mcp_server.server import app\n\n"
+        f"@app.tool(\n    name=\"{name}\",\n    description=\"{description}\",\n)\n"
+        f"async def {func_name}({args_sig}) -> Any:\n"
+        f"{body}\n"
+    )
+
+    module_path = tools_dir / f"{func_name}.py"
+    module_path.write_text(module_content, encoding="utf-8")
+
+    load_tools()
+    return module_path
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Forge MCP tool modules from a spec file")
+    parser.add_argument("--spec", required=True, help="Path to JSON tool specification")
+    args = parser.parse_args(argv)
+    spec = json.loads(Path(args.spec).read_text())
+    forge(spec)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/runtime/test_toolforge.py
+++ b/tests/runtime/test_toolforge.py
@@ -1,0 +1,35 @@
+import asyncio
+import importlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "mcp_server" / "src"))
+from mcp_server.server import load_tools
+
+
+def test_toolforge_creates_and_executes(tmp_path):
+    spec = {
+        "name": "toolforge_adder",
+        "description": "Add two numbers",
+        "input_schema": {"a": "int", "b": "int"},
+        "code": "return {'sum': a + b}",
+    }
+    spec_path = tmp_path / "spec.json"
+    spec_path.write_text(json.dumps(spec))
+
+    subprocess.run(
+        [sys.executable, "-m", "src.agents.toolforge", "--spec", str(spec_path)],
+        check=True,
+    )
+
+    modules = load_tools()
+    assert f"mcp_server.tools.{spec['name']}" in modules
+
+    mod = importlib.import_module(f"mcp_server.tools.{spec['name']}")
+    fn = getattr(mod, spec["name"])
+    result = asyncio.run(fn(a=2, b=3))
+    assert result["sum"] == 5
+
+    Path(mod.__file__).unlink(missing_ok=True)


### PR DESCRIPTION
## Summary
- add `toolforge` CLI to forge MCP tool modules from JSON specs and reload dynamic registry
- include unit test exercising generated tool

## Changes
- new `src/agents/toolforge.py` for writing tool modules and calling loader
- new runtime test `test_toolforge.py`

## Verification
- `pre-commit run --all-files`
- `pytest -q tests/runtime/test_toolforge.py`
- `pytest -q tests/runtime` *(fails: multiple existing tests)*

## Runtime impact
- none; toolforge runs on demand to generate modules

## Observability
- no changes

## Rollback
- revert commits or delete generated tool modules


------
https://chatgpt.com/codex/tasks/task_e_68ad05daa1a88328910452385c46ee79