### PR TITLE
Add MCP tool template and loader utility

### DIFF
--- a/mcp_server/README.md
+++ b/mcp_server/README.md
@@ -21,6 +21,18 @@ async def your_tool(...):
     ...
 ```
 
+## Naming conventions
+
+Per the [MCP guide](../docs/mcp.md), tool modules and decorator names should use
+`snake_case`, while parameter names follow `camelCase`. Adhering to these
+conventions ensures MCP clients can discover and invoke tools reliably.
+
+To bootstrap a new tool from the provided template, run:
+```bash
+python src/mcp_server/server.py --add-tool my_tool
+```
+This copies `tools/_template.py` into the tools package.
+
 ## Configuration
 Example MCP server configuration:
 ```json

--- a/mcp_server/src/mcp_server/server.py
+++ b/mcp_server/src/mcp_server/server.py
@@ -4,11 +4,13 @@ import argparse
 import importlib
 import pkgutil
 import sys
+from pathlib import Path
 
 from mcp.server.fastmcp import FastMCP
 
 
 # Dynamic tool loader: import all modules in mcp_server.tools
+
 def load_tools() -> list[str]:
     imported = []
     import mcp_server.tools as tools_pkg
@@ -19,18 +21,44 @@ def load_tools() -> list[str]:
     return imported
 
 
+def copy_tool_template(name: str, dest_dir: Path | None = None) -> Path:
+    """Copy the tool template into the tools package.
+
+    Args:
+        name: ``snake_case`` name for the new tool module.
+        dest_dir: Optional destination directory; defaults to the tools package.
+
+    Returns:
+        Path to the created module.
+    """
+    template = Path(__file__).resolve().parents[2] / "tools" / "_template.py"
+    destination = (Path(__file__).resolve().parent / "tools") if dest_dir is None else dest_dir
+    destination.mkdir(parents=True, exist_ok=True)
+    target = destination / f"{name}.py"
+    content = template.read_text().replace("tool_name", name)
+    target.write_text(content)
+    return target
+
+
 app = FastMCP("myCustomPythonAgent")
 
 
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--transport", choices=["stdio", "sse"], default="stdio")
+    parser.add_argument("--add-tool", help="Copy template into tools package and exit.")
     args = parser.parse_args()
 
-    loaded = load_tools()
+    if args.add_tool:
+        path = copy_tool_template(args.add_tool)
+        print(f"created {path}")
+        return
+
+    load_tools()
     # Register tools decorated with @app.tool() in loaded modules
     # FastMCP auto-discovers @app.tool() methods defined with the same app instance.
-    # Ensure your tool modules import pp from this module: rom mcp_server.server import app
+    # Ensure your tool modules import app from this module:
+    # from mcp_server.server import app
     if args.transport == "stdio":
         app.run(transport="stdio")
     else:
@@ -39,4 +67,5 @@ def main() -> None:
 
 
 if __name__ == "__main__":
+    main()
     main()

--- a/mcp_server/tools/_template.py
+++ b/mcp_server/tools/_template.py
@@ -1,0 +1,23 @@
+"""Template for creating new MCP tools.
+
+Copy this file and replace placeholders with your tool logic.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from mcp_server.server import app
+
+
+@app.tool(name="tool_name", description="Short description of the tool.")
+async def tool_name(exampleParam: str) -> dict[str, Any]:
+    """Explain the tool.
+
+    Args:
+        exampleParam: Description of the parameter.
+
+    Returns:
+        {"resultKey": "description"}  # Result schema hint.
+    """
+    raise NotImplementedError("Implement your tool logic")

--- a/tests/mcp_server/test_template_loader.py
+++ b/tests/mcp_server/test_template_loader.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "mcp_server" / "src"))
+
+from mcp_server.server import copy_tool_template
+
+
+def test_copy_tool_template(tmp_path: Path) -> None:
+    dest = tmp_path / "tools"
+    created = copy_tool_template("sample_tool", dest)
+    assert created.exists()
+    assert created.read_text().count("sample_tool") >= 2
+


### PR DESCRIPTION
## Summary
- add `_template.py` tool scaffold and CLI to copy it
- document MCP naming conventions and template workflow
- test template copy helper

## Changes
- create `mcp_server/tools/_template.py`
- add `copy_tool_template` helper and `--add-tool` flag in `server.py`
- describe snake_case tools & camelCase params in README and template usage
- add unit test for template loader

## Verification
- `pre-commit run --all-files`
- `pytest -q tests/mcp_server/test_template_loader.py`
- `pytest -q tests/runtime` *(fails: test suite has existing issues)*

## Runtime impact
- optional CLI flag for copying tool template; no streaming/runtime code paths affected

## Observability
- no changes to telemetry or event shapes

## Rollback
- revert commits: `git revert 9e9e8ab e21224d 32a1895`

------
https://chatgpt.com/codex/tasks/task_e_68ad05db47ec8328add69054c47ff7b7