### PR TITLE
[telemetry] instrument MCP tools and add runtime test

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,0 +1,20 @@
+# Telemetry
+
+Tool wrappers in `mcp_server_wrapper.py` emit events to a JSON Lines log
+(`telemetry.jsonl`). The file location can be overridden with the
+`SUPER_ALITA_TELEMETRY_FILE` environment variable.
+
+## Event sequence
+
+Each tool invocation records the following events:
+
+1. **AbilityCalled** – emitted before execution begins.
+2. **AbilitySucceeded** or **AbilityFailed** – emitted after the tool
+   returns or raises an error, including duration and output hash.
+3. **ArtifactCreated** – emitted when a tool's result exceeds ~200 KB. The
+   full output is stored as an external artifact and the event includes its
+   size and SHA-256 hash.
+
+These events help verify tool behaviour during tests and can be inspected by
+reading the `telemetry.jsonl` file.
+

--- a/mcp_server_wrapper.py
+++ b/mcp_server_wrapper.py
@@ -1,8 +1,15 @@
 #!/usr/bin/env python3
+import functools
+import hashlib
+import inspect
+import json
 import logging
 import os
 import sys
-from typing import Any
+import time
+import uuid
+from pathlib import Path
+from typing import Any, Awaitable, Callable
 
 # Remove the workspace from the Python path to avoid conflicts
 sys.path = [p for p in sys.path if "super-alita-clean" not in p and "ATLAI" not in p]
@@ -55,6 +62,89 @@ except ImportError as e:
 
 
 app = FastMCP("myCustomPythonAgent")
+
+
+TELEMETRY_FILE = Path(os.environ.get("SUPER_ALITA_TELEMETRY_FILE", "telemetry.jsonl"))
+
+
+def _emit_event(event_type: str, **data: Any) -> None:
+    TELEMETRY_FILE.parent.mkdir(parents=True, exist_ok=True)
+    with TELEMETRY_FILE.open("a", encoding="utf-8") as fp:
+        json.dump({"type": event_type, **data}, fp)
+        fp.write("\n")
+
+
+def _telemetry_wrapper(name: str) -> Callable[[Callable[..., Awaitable[Any]]], Callable[..., Awaitable[Any]]]:
+    def decorator(func: Callable[..., Awaitable[Any]]) -> Callable[..., Awaitable[Any]]:
+        @functools.wraps(func)
+        async def wrapped(*args: Any, **kwargs: Any) -> Any:
+            span_id = uuid.uuid4().hex
+            args_hash = hashlib.sha256(
+                json.dumps({"args": args, "kwargs": kwargs}, sort_keys=True).encode()
+            ).hexdigest()
+            _emit_event("AbilityCalled", tool=name, span_id=span_id, args_hash=args_hash)
+            start = time.perf_counter()
+            try:
+                result = await func(*args, **kwargs)
+                duration_ms = int((time.perf_counter() - start) * 1000)
+                output_json = json.dumps(result, sort_keys=True)
+                output_bytes = output_json.encode()
+                output_hash = hashlib.sha256(output_bytes).hexdigest()
+                if len(output_bytes) > 200_000:
+                    sha = hashlib.sha256(output_bytes).hexdigest()
+                    artifact_id = sha[:8]
+                    artifact_path = TELEMETRY_FILE.with_name(f"artifact_{artifact_id}.json")
+                    artifact_path.write_bytes(output_bytes)
+                    _emit_event(
+                        "ArtifactCreated",
+                        tool=name,
+                        artifact_bytes=len(output_bytes),
+                        sha256=sha,
+                    )
+                    result = {
+                        "_artifact": {
+                            "artifact_id": artifact_id,
+                            "sha256": sha,
+                            "bytes": len(output_bytes),
+                        }
+                    }
+                _emit_event(
+                    "AbilitySucceeded",
+                    tool=name,
+                    span_id=span_id,
+                    duration_ms=duration_ms,
+                    output_hash=output_hash,
+                )
+                return result
+            except Exception as e:  # pragma: no cover - error path
+                duration_ms = int((time.perf_counter() - start) * 1000)
+                _emit_event(
+                    "AbilityFailed",
+                    tool=name,
+                    span_id=span_id,
+                    duration_ms=duration_ms,
+                    error=str(e),
+                )
+                raise
+
+        wrapped.__signature__ = inspect.signature(func, eval_str=False)
+        return wrapped
+
+    return decorator
+
+
+_original_tool = FastMCP.tool
+
+
+def _instrumented_tool(self: FastMCP, *t_args: Any, **t_kwargs: Any):
+    def decorator(func: Callable[..., Awaitable[Any]]) -> Callable[..., Awaitable[Any]]:
+        name = t_kwargs.get("name", func.__name__)
+        return _original_tool(self, *t_args, **t_kwargs)(_telemetry_wrapper(name)(func))
+
+    return decorator
+
+
+FastMCP.tool = _instrumented_tool  # type: ignore[assignment]
 
 
 @app.tool(

--- a/tests/runtime/test_generated_tools.py
+++ b/tests/runtime/test_generated_tools.py
@@ -1,0 +1,52 @@
+import asyncio
+import importlib
+import json
+import sys
+from pathlib import Path
+
+
+class ToolForge:
+    """Minimal tool generator used for tests."""
+
+    def __init__(self, tools_dir: Path) -> None:
+        self.tools_dir = tools_dir
+
+    def generate(self, name: str) -> Path:
+        code = (
+            "from mcp_server.server import app\n"
+            f"@app.tool(name='{name}', description='generated tool')\n"
+            f"async def {name}() -> dict[str, str]:\n"
+            "    return {'content': 'x' * 250000}\n"
+        )
+        path = self.tools_dir / f"{name}.py"
+        path.write_text(code)
+        return path
+
+
+def test_generated_tool(tmp_path, monkeypatch) -> None:
+    tools_dir = Path("mcp_server/src/mcp_server/tools").resolve()
+    forge = ToolForge(tools_dir)
+    module_path = forge.generate("generated_tool")
+    telemetry_file = tmp_path / "telemetry.jsonl"
+    monkeypatch.setenv("SUPER_ALITA_TELEMETRY_FILE", str(telemetry_file))
+    try:
+
+        sys.path.insert(0, str(Path("mcp_server/src").resolve()))
+        import mcp_server_wrapper  # patch FastMCP.tool for telemetry
+        importlib.invalidate_caches()
+        import mcp_server.server  # ensure server imports
+        module = importlib.import_module("mcp_server.tools.generated_tool")
+        asyncio.run(module.generated_tool())
+
+        events = [json.loads(line) for line in telemetry_file.read_text().splitlines()]
+        kinds = {e["type"] for e in events}
+        assert {"AbilityCalled", "AbilitySucceeded", "ArtifactCreated"} <= kinds
+    finally:
+        if module_path.exists():
+            module_path.unlink()
+        sys.modules.pop("mcp_server.tools.generated_tool", None)
+        sys.modules.pop("mcp_server.server", None)
+        sys.modules.pop("mcp_server", None)
+        path = str(Path("mcp_server/src").resolve())
+        if path in sys.path:
+            sys.path.remove(path)


### PR DESCRIPTION
## Summary
- emit AbilityCalled/Succeeded/Failed and ArtifactCreated events for MCP tools
- exercise ToolForge-generated tool and verify telemetry logging
- document telemetry events

## Changes
- wrap FastMCP.tool to log telemetry and create artifacts for large outputs
- add `tests/runtime/test_generated_tools.py`
- add `docs/telemetry.md`

## Verification
- `pre-commit run --files mcp_server_wrapper.py tests/runtime/test_generated_tools.py docs/telemetry.md`
- `pytest -q tests/runtime/test_generated_tools.py`
- `pytest -q tests/runtime` *(fails: aiohttp.client_exceptions.ClientConnectorError, AssertionError in existing tests)*

## Runtime impact
- adds lightweight file I/O for telemetry; no protocol changes

## Observability
- new telemetry events in `telemetry.jsonl` for every MCP tool invocation

## Rollback
- revert commits to restore previous behaviour

------
https://chatgpt.com/codex/tasks/task_e_68ad05df1f4c83288788cd2af5b24253