### PR TITLE
mcp: setup script updates mcp config

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ curl http://127.0.0.1:8080/healthz
 
 Debug utilities (`debug_fixed.py`, `debug_matching.py`, `utility_debug.py`) are under `scripts/`.
 
+## MCP Server Installation Links
+
+VS Code can install MCP server definitions directly via special links:
+
+- [Sample install](vscode:mcp/install?url=https://example.com/mcp.json)
+
 ## LLM Fallback Configuration
 
 Set `LLM_MODEL=auto` to enable automatic provider selection.

--- a/docs/mcp_server_definition_provider_snippets.md
+++ b/docs/mcp_server_definition_provider_snippets.md
@@ -1,0 +1,55 @@
+# MCP Server Definition Provider Snippets
+
+Examples for using `vscode.lm.registerMcpServerDefinitionProvider` in extensions.
+
+## TypeScript
+
+```typescript
+import * as vscode from 'vscode';
+
+class ExampleMcpProvider implements vscode.lm.McpServerDefinitionProvider {
+    provideMcpServerDefinitions(_token: vscode.CancellationToken) {
+        return [{
+            id: 'example',
+            displayName: 'Example MCP',
+            command: 'node',
+            args: ['server.js'],
+            env: {}
+        }];
+    }
+}
+
+export function activate() {
+    vscode.lm.registerMcpServerDefinitionProvider(
+        'example-mcp-provider',
+        new ExampleMcpProvider()
+    );
+}
+```
+
+## Node.js (CommonJS)
+
+```javascript
+const vscode = require('vscode');
+
+class ExampleMcpProvider {
+  provideMcpServerDefinitions() {
+    return [{
+      id: 'example',
+      displayName: 'Example MCP',
+      command: 'node',
+      args: ['server.js'],
+      env: {}
+    }];
+  }
+}
+
+function activate() {
+  vscode.lm.registerMcpServerDefinitionProvider(
+    'example-mcp-provider',
+    new ExampleMcpProvider()
+  );
+}
+
+module.exports = { activate };
+```

--- a/tests/runtime/test_setup_mcp_ps1.py
+++ b/tests/runtime/test_setup_mcp_ps1.py
@@ -1,0 +1,25 @@
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+PWSH = shutil.which("pwsh")
+pytestmark = pytest.mark.skipif(PWSH is None, reason="pwsh not installed")
+
+
+def test_setup_mcp_adds_server(tmp_path):
+    repo = Path(__file__).resolve().parents[2]
+    script = repo / "tools" / "Setup-MCP.ps1"
+    config = tmp_path / "mcp.json"
+    sample = {
+        "servers": {}
+    }
+    config.write_text(json.dumps(sample))
+
+    subprocess.run([PWSH, str(script), "-AddTool", "Example", "-ConfigPath", str(config)], check=True)
+
+    data = json.loads(config.read_text())
+    assert "Example" in data["servers"]
+

--- a/tools/Setup-MCP.ps1
+++ b/tools/Setup-MCP.ps1
@@ -1,0 +1,60 @@
+#!/usr/bin/env pwsh
+<#!
+.SYNOPSIS
+    Helper script to register new MCP tool servers
+
+.DESCRIPTION
+    Adds a new server entry to the VS Code `.vscode/mcp.json` file.
+
+.PARAMETER AddTool
+    Name of the tool server to register
+
+.PARAMETER ConfigPath
+    Optional path to the mcp.json file (defaults to `.vscode/mcp.json`)
+#>
+
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$AddTool,
+    [string]$ConfigPath = ".vscode/mcp.json"
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not (Test-Path $ConfigPath)) {
+    Write-Error "mcp config not found at $ConfigPath"
+    exit 1
+}
+
+$config = Get-Content $ConfigPath -Raw | ConvertFrom-Json
+
+if (-not $config.servers) {
+    $config | Add-Member -MemberType NoteProperty -Name servers -Value @{}
+}
+
+if ($config.servers.$AddTool) {
+    Write-Host "MCP server '$AddTool' already exists" -ForegroundColor Yellow
+    exit 0
+}
+
+$serverEntry = @{
+    type    = "stdio"
+    command = '${workspaceFolder}\.venv\Scripts\python.exe'
+    args    = @(
+        '${workspaceFolder}\mcp_server_wrapper.py',
+        '--tool',
+        $AddTool
+    )
+    env     = @{
+        GEMINI_API_KEY     = '${env:GEMINI_API_KEY}'
+        MCP_AGENT_API_KEY = '${env:GEMINI_API_KEY}'
+        PYTHONPATH        = ''
+    }
+    cwd     = '${workspaceFolder}'
+}
+
+$config.servers | Add-Member -NotePropertyName $AddTool -NotePropertyValue $serverEntry
+$config | ConvertTo-Json -Depth 5 | Set-Content -Path $ConfigPath
+
+Write-Host "Added MCP server '$AddTool' to $ConfigPath" -ForegroundColor Green
+


### PR DESCRIPTION
## Summary
- add Setup-MCP.ps1 to register new tool servers in `.vscode/mcp.json`
- document `vscode.lm.registerMcpServerDefinitionProvider` usage for TS/Node
- show `vscode:mcp/install` link example in README

## Changes
- add PowerShell helper that appends server entries
- new docs with TypeScript and CommonJS snippets
- README section for `vscode:mcp/install` URLs
- basic test for Setup-MCP script (skips if `pwsh` missing)

## Verification
- `pre-commit run --all-files`
- `pytest -q tests/runtime` *(fails: FileNotFoundError: 'AbilityCalled' not in event set and other existing test failures)*

## Runtime impact
- none; script only alters local configuration files

## Observability
- no changes

## Rollback
- revert this PR

------
https://chatgpt.com/codex/tasks/task_e_68ad05de3a8c8328b95ea2c43d0bb83c