### PR TITLE
copilot: add context builder

### DIFF
--- a/src/copilot/__init__.py
+++ b/src/copilot/__init__.py
@@ -1,0 +1,1 @@
+"""Copilot utilities."""

--- a/src/copilot/context_builder.py
+++ b/src/copilot/context_builder.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import ast
+import json
+from hashlib import sha256
+from typing import Any, Iterable
+
+
+@dataclass(slots=True)
+class OpenFile:
+    """Representation of a file opened in the editor."""
+
+    path: str
+    content: str
+    selection: tuple[int, int] | None = None
+
+
+@dataclass(slots=True)
+class ChatContext:
+    """Inputs provided by the client to build the copilot context."""
+
+    open_files: list[OpenFile]
+    attachments: list[OpenFile] = field(default_factory=list)
+    quality_mode: str = "fast"
+
+
+@dataclass(slots=True)
+class CopilotContext:
+    """Context derived from the chat request for the model."""
+
+    top_comments: dict[str, str]
+    imports: dict[str, list[str]]
+    symbols: dict[str, list[str]]
+    selections: dict[str, str]
+    attachments: list[str]
+    content_hash: str
+    quality_mode: str
+
+
+def _extract_top_comment(source: str) -> str | None:
+    """Return the leading comment block at the top of ``source`` if present."""
+
+    lines: list[str] = source.splitlines()
+    comment_lines: list[str] = []
+    for line in lines:
+        striped = line.lstrip()
+        if striped.startswith("#"):
+            comment_lines.append(striped[1:].lstrip())
+        elif striped == "":
+            if comment_lines:
+                comment_lines.append("")
+        else:
+            break
+    return "\n".join(comment_lines).strip() or None
+
+
+def _extract_imports(source: str) -> list[str]:
+    """Return top-level import statements from ``source``."""
+
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return []
+
+    imports: list[str] = []
+    for node in tree.body:
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                imports.append(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            for alias in node.names:
+                name = f"{module}.{alias.name}" if module else alias.name
+                imports.append(name)
+    return imports
+
+
+def _extract_symbols(source: str) -> list[str]:
+    """Return names of top-level classes and functions defined in ``source``."""
+
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return []
+
+    symbols: list[str] = []
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            symbols.append(node.name)
+    return symbols
+
+
+def _extract_selection(content: str, selection: tuple[int, int]) -> str:
+    start, end = selection
+    lines = content.splitlines()
+    selected = lines[start - 1 : end]
+    return "\n".join(selected)
+
+
+def _compute_content_hash(open_files: Iterable[OpenFile], attachments: Iterable[OpenFile]) -> str:
+    data = {
+        "open_files": [
+            {"path": f.path, "content": f.content, "selection": f.selection}
+            for f in sorted(open_files, key=lambda f: f.path)
+        ],
+        "attachments": [
+            {"path": f.path, "content": f.content, "selection": f.selection}
+            for f in sorted(attachments, key=lambda f: f.path)
+        ],
+    }
+    canonical = json.dumps(data, sort_keys=True, separators=(",", ":")).encode()
+    return sha256(canonical).hexdigest()
+
+
+def build_copilot_context(chat: ChatContext) -> CopilotContext:
+    """Derive a :class:`CopilotContext` from ``chat`` inputs."""
+
+    top_comments: dict[str, str] = {}
+    imports: dict[str, list[str]] = {}
+    symbols: dict[str, list[str]] = {}
+    selections: dict[str, str] = {}
+
+    for file in chat.open_files:
+        if (comment := _extract_top_comment(file.content)) is not None:
+            top_comments[file.path] = comment
+        imports[file.path] = _extract_imports(file.content)
+        symbols[file.path] = _extract_symbols(file.content)
+        if file.selection is not None:
+            selections[file.path] = _extract_selection(file.content, file.selection)
+
+    attachments_paths = [a.path for a in chat.attachments]
+    content_hash = _compute_content_hash(chat.open_files, chat.attachments)
+
+    return CopilotContext(
+        top_comments=top_comments,
+        imports=imports,
+        symbols=symbols,
+        selections=selections,
+        attachments=attachments_paths,
+        content_hash=content_hash,
+        quality_mode=chat.quality_mode,
+    )
+

--- a/tests/runtime/test_copilot_context_builder.py
+++ b/tests/runtime/test_copilot_context_builder.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from src.copilot.context_builder import (
+    ChatContext,
+    OpenFile,
+    build_copilot_context,
+)
+
+
+def test_build_copilot_context_extracts_components() -> None:
+    source = (
+        "# module comment\n"
+        "\n"
+        "import os\n"
+        "\n"
+        "class Foo:\n"
+        "    pass\n"
+        "\n"
+        "def bar():\n"
+        "    pass\n"
+    )
+    open_file = OpenFile(path="a.py", content=source, selection=(5, 6))
+    attachment = OpenFile(path="notes.txt", content="extra")
+    chat = ChatContext(open_files=[open_file], attachments=[attachment])
+
+    context = build_copilot_context(chat)
+
+    assert context.top_comments["a.py"] == "module comment"
+    assert "os" in context.imports["a.py"]
+    assert {"Foo", "bar"} <= set(context.symbols["a.py"])
+    assert context.selections["a.py"].splitlines()[0].startswith("class Foo")
+    assert context.attachments == ["notes.txt"]
+    assert context.quality_mode == "fast"
+
+
+def test_content_hash_deterministic() -> None:
+    f1 = OpenFile(path="a.py", content="print('a')\n")
+    f2 = OpenFile(path="b.py", content="print('b')\n")
+
+    ctx1 = ChatContext(open_files=[f1, f2])
+    ctx2 = ChatContext(open_files=[f2, f1])
+
+    hash1 = build_copilot_context(ctx1).content_hash
+    hash2 = build_copilot_context(ctx2).content_hash
+
+    assert hash1 == hash2


### PR DESCRIPTION
## Summary
- add context builder dataclasses for Copilot chat
- compute deterministic content hash and expose build helper
- cover context extraction with focused tests

## Changes
- new `src/copilot/context_builder.py`
- unit test for context extraction and hash determinism

## Verification
- `pre-commit run --all-files` (passed)
- `pytest -q tests/runtime/test_copilot_context_builder.py` (passed)
- `pytest -q tests/runtime` (fails: AssertionError in existing runtime tests)

## Runtime impact
- builds small in-memory context; negligible latency impact

## Observability
- no new telemetry or event shapes

## Rollback
- revert commit `copilot: add context builder`


------
https://chatgpt.com/codex/tasks/task_e_68ad06f3d17483289542e36429050bae