### PR TITLE
runtime: emit copilot context telemetry

### DIFF
--- a/src/reug_runtime/config.py
+++ b/src/reug_runtime/config.py
@@ -100,6 +100,7 @@ class Settings:
     max_retries: int = _getenv_int("REUG_EXEC_MAX_RETRIES", 1)
     retry_base_ms: int = _getenv_int("REUG_RETRY_BASE_MS", 250)
     schema_enforce: bool = _getenv_bool("REUG_SCHEMA_ENFORCE", True)
+    copilot_context: bool = _getenv_bool("REUG_COPILOT_CONTEXT", True)
 
     # Observability / storage (used indirectly by your EventBus/KG)
     event_log_dir: str | None = _getenv("REUG_EVENT_LOG_DIR")

--- a/src/reug_runtime/router.py
+++ b/src/reug_runtime/router.py
@@ -17,11 +17,15 @@ conflicts are resolved or provider-specific logic evolves.
 import asyncio
 import json
 import re
+import time
+import uuid
 from collections.abc import AsyncGenerator
 from typing import Any
 
 from fastapi import APIRouter, Request
 from fastapi.responses import StreamingResponse
+
+from src.telemetry import build_copilot_context
 
 from .config import SETTINGS
 
@@ -78,12 +82,53 @@ async def execute_turn(
     kg: Any,
     model: Any,
 ) -> AsyncGenerator[str, None]:
+    """Run a single streaming turn and yield chunks to the client.
+
+    The function keeps a minimal contract compatible with the tests in
+    ``tests/runtime``.  It emits telemetry events around tool execution and
+    preserves the `<tool_call>`/`<tool_result>`/`<final_answer>` streaming
+    protocol.
+
+    Args:
+        user_msg: The raw user message for this turn.
+        session_id: Session identifier.
+        event_bus: Event bus used for telemetry emission.
+        registry: Ability registry capable of executing tools.
+        kg: Knowledge graph handle (unused, kept for future expansion).
+        model: LLM-like client implementing ``stream_chat``.
+
+    Yields:
+        Text chunks to be streamed to the client.
+    """
+
+    correlation_id = f"{session_id}-{int(time.time()*1000)}"
+    await event_bus.emit({"type": "TaskStarted", "correlation_id": correlation_id, "goal": user_msg})
+
+    system_prompt = "Use tools when helpful. End with <final_answer>{...}</final_answer>."
+    if SETTINGS.copilot_context:
+        span_id = str(uuid.uuid4())
+        await event_bus.emit(
+            {
+                "type": "AbilityCalled",
+                "tool": "build_copilot_context",
+                "correlation_id": correlation_id,
+                "span_id": span_id,
+            }
+        )
+        ctx = build_copilot_context(user_message=user_msg, session_id=session_id)
+        await event_bus.emit(
+            {
+                "type": "AbilitySucceeded",
+                "tool": "build_copilot_context",
+                "correlation_id": correlation_id,
+                "span_id": span_id,
+            }
+        )
+        system_prompt = f"{ctx}\n{system_prompt}"
+
     parser = _Parser()
     messages: list[dict[str, str]] = [
-        {
-            "role": "system",
-            "content": "Use tools when helpful. End with <final_answer>{...}</final_answer>.",
-        },
+        {"role": "system", "content": system_prompt},
         {"role": "user", "content": user_msg},
     ]
     cycles = 0
@@ -97,23 +142,55 @@ async def execute_turn(
             if call:
                 tool = call.get("tool", "")
                 args = call.get("args", {})
+                span_id = str(uuid.uuid4())
+                await event_bus.emit(
+                    {
+                        "type": "AbilityCalled",
+                        "tool": tool,
+                        "correlation_id": correlation_id,
+                        "span_id": span_id,
+                    }
+                )
                 try:
                     result = await asyncio.wait_for(
                         registry.execute(tool, args), timeout=SETTINGS.tool_timeout_s
                     )
                 except Exception as e:
+                    await event_bus.emit(
+                        {
+                            "type": "AbilityFailed",
+                            "tool": tool,
+                            "correlation_id": correlation_id,
+                            "span_id": span_id,
+                            "error": str(e),
+                        }
+                    )
                     yield f'<tool_error tool="{tool}">{{"error":{json.dumps(str(e))}}}</tool_error>'
                     break
+                await event_bus.emit(
+                    {
+                        "type": "AbilitySucceeded",
+                        "tool": tool,
+                        "correlation_id": correlation_id,
+                        "span_id": span_id,
+                    }
+                )
                 block = f'<tool_result tool="{tool}">{json.dumps(result)}</tool_result>'
                 messages.append({"role": "assistant", "content": block})
                 yield block
                 tool_called = True
-        if parser.take_final():
+        final = parser.take_final()
+        if final:
+            await event_bus.emit({"type": "TaskSucceeded", "correlation_id": correlation_id})
+            yield f"<final_answer>{json.dumps(final)}</final_answer>"
             return
         if not tool_called:
             break
     if not parser.take_final():
         payload = {"content": "done", "citations": []}
+        await event_bus.emit(
+            {"type": "TaskFailed", "correlation_id": correlation_id, "reason": "no_final_answer"}
+        )
         yield f"<final_answer>{json.dumps(payload)}</final_answer>"
 
 

--- a/src/telemetry/__init__.py
+++ b/src/telemetry/__init__.py
@@ -14,6 +14,29 @@ from .mcp_broadcaster import (
 )
 from .plugin_wrapper import wrap_plugin_for_telemetry
 
+# ---------------------------------------------------------------------------
+# Copilot context helpers
+# ---------------------------------------------------------------------------
+
+
+def build_copilot_context(user_message: str, session_id: str) -> str:
+    """Construct a lightweight context string for Copilot prompts.
+
+    The function intentionally keeps the structure simple – the goal is to
+    surface user/session details into telemetry without imposing a specific
+    prompt format.  Callers may prepend this context to system prompts or use it
+    in event metadata.
+
+    Args:
+        user_message: Raw user message for the current turn.
+        session_id: Identifier for the active conversation/session.
+
+    Returns:
+        A single string embedding the session and user message.
+    """
+
+    return f"session={session_id} user={user_message}"
+
 __all__ = [
     "EventTypes",
     "MCPTelemetryBroadcaster",
@@ -21,4 +44,5 @@ __all__ = [
     "broadcast_agent_event",
     "get_broadcaster",
     "wrap_plugin_for_telemetry",
+    "build_copilot_context",
 ]

--- a/tests/runtime/test_copilot_context.py
+++ b/tests/runtime/test_copilot_context.py
@@ -1,0 +1,30 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from unittest.mock import patch
+
+from reug_runtime.router import router
+import reug_runtime.config as config
+from tests.runtime.fakes import FakeAbilityRegistry, FakeEventBus, FakeKG, FakeLLM
+
+
+def _make_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(router)
+    app.state.event_bus = FakeEventBus()
+    app.state.ability_registry = FakeAbilityRegistry()
+    app.state.kg = FakeKG()
+    app.state.llm_model = FakeLLM()
+    return app
+
+
+def test_copilot_context_emits_events(monkeypatch) -> None:
+    app = _make_app()
+    monkeypatch.setattr(config.SETTINGS, "copilot_context", True)
+    with patch("reug_runtime.router.build_copilot_context", return_value="ctx"):
+        client = TestClient(app)
+        resp = client.post("/v1/chat/stream", json={"message": "hi", "session_id": "s1"})
+        assert resp.status_code == 200
+    events = app.state.event_bus.events
+    kinds = [e["type"] for e in events if e.get("tool") == "build_copilot_context"]
+    assert "AbilityCalled" in kinds
+    assert "AbilitySucceeded" in kinds


### PR DESCRIPTION
## Summary
- capture copilot context in telemetry and expose toggle
- stream ability events for context builder and tool executions
- add regression test for copilot context events

## Changes
- add `build_copilot_context` helper in telemetry package
- wire context builder into runtime router with AbilityCalled/AbilitySucceeded events
- introduce `REUG_COPILOT_CONTEXT` config flag
- add test covering ability events for context builder

## Verification
- `pre-commit run --files src/reug_runtime/router.py src/reug_runtime/config.py src/telemetry/__init__.py tests/runtime/test_copilot_context.py`
- `pytest -q tests/runtime/test_copilot_context.py tests/runtime/test_router_smoke.py tests/runtime/test_execute_turn_stream.py`

## Runtime impact
- extra telemetry events; negligible latency

## Observability
- new events for build_copilot_context ability; configurable via `REUG_COPILOT_CONTEXT`

## Rollback
- revert commits


------
https://chatgpt.com/codex/tasks/task_e_68ad0700a1d48328b6b0815a87a53dc4