### PR TITLE
build: ignore nested out directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,7 +120,7 @@ metrics_*.json
 
 # VS Code extension development
 *.vsix
-out/
+**/out/
 node_modules/
 .vscode-test/
 


### PR DESCRIPTION
## Summary
- broaden ignored build directories so any `out` folder is excluded

## Changes
- replace root-only `out/` rule with recursive `**/out/`

## Verification
- `pre-commit run --all-files`
- `PYTHONPATH=./src pytest -q tests/runtime` *(fails: Interrupted: 54 errors during collection)*

## Runtime impact
- none

## Observability
- none

## Rollback
- revert commit

------
https://chatgpt.com/codex/tasks/task_e_68ad12fd76e883289218592dbaec4873