### PR TITLE
backend: add MCP and skillset servers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,16 +12,22 @@ deps: ## Install runtime + test deps
 	pip install -r requirements.txt -r requirements-test.txt
 
 run: ## Start FastAPI dev server on :8080
-	uvicorn app:app --reload --port 8080
+        uvicorn app:app --reload --port 8080
 
 test: ## Run full tests (runtime suite)
-	PYTHONPATH=./src pytest -v tests/runtime/
+        PYTHONPATH=./src pytest -v tests/runtime/
 
 test-smoke: ## Quick smoke test
 	PYTHONPATH=./src pytest -q tests/runtime/test_router_smoke.py
 
 lint: ## Run pre-commit hooks
-	pre-commit run --all-files
+        pre-commit run --all-files
+
+run-mcp-backend: ## Start the backend MCP server
+        python backend/mcp_server.py
+
+run-skillset-backend: ## Start the backend skillset server
+        uvicorn backend.skillset_server:app --reload --port 8001
 
 env: ## Create .env from template
 	@if [ ! -f .env ]; then cp .env.example .env && echo "Created .env"; else echo ".env already exists"; fi

--- a/backend/mcp_server.py
+++ b/backend/mcp_server.py
@@ -1,0 +1,59 @@
+"""Minimal MCP server exposing search and fetch tools.
+
+This module provides :func:`create_mcp_server` which returns a
+:class:`FastMCP` instance.  The server registers two tools:
+
+``search(query: str) -> list[str]``
+    Return IDs of items whose description contains the query text.
+
+``fetch(item_id: str) -> dict``
+    Fetch the metadata for a given item ID.
+
+The implementation uses an in-memory data set so the tools remain pure
+and easy to test.  The module can be executed directly to start a stdio
+MCP server:
+
+``python backend/mcp_server.py``
+"""
+from __future__ import annotations
+
+from typing import Dict, List
+
+from mcp.server.fastmcp import FastMCP
+
+# In-memory catalogue used by the search/fetch tools.  Keeping the data
+# local avoids network access during tests.
+_DATA: Dict[str, dict] = {
+    "1": {"title": "Fix login bug"},
+    "2": {"title": "Add dark mode"},
+    "3": {"title": "Improve documentation"},
+}
+
+app = FastMCP("backend-mcp")
+
+
+@app.tool()
+async def search(query: str) -> List[str]:
+    """Return IDs of entries whose title contains ``query``."""
+    q = query.lower()
+    return [key for key, meta in _DATA.items() if q in meta["title"].lower()]
+
+
+@app.tool()
+async def fetch(item_id: str) -> Dict[str, str]:
+    """Return metadata for ``item_id``.
+
+    Raises ``KeyError`` if the ID is unknown.
+    """
+    if item_id not in _DATA:
+        raise KeyError(item_id)
+    return _DATA[item_id]
+
+
+def create_mcp_server() -> FastMCP:
+    """Return the configured MCP server."""
+    return app
+
+
+if __name__ == "__main__":  # pragma: no cover - manual run helper
+    create_mcp_server().run(transport="stdio")

--- a/backend/skillset_server.py
+++ b/backend/skillset_server.py
@@ -1,0 +1,53 @@
+"""Simple skillset server exposing a signed ``search_issues_skill``.
+
+The server uses FastAPI and verifies HMAC signatures on incoming
+requests.  This mirrors a typical Skillset setup where the caller
+authenticates using a shared secret.
+"""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import os
+from typing import Any, Dict, List
+
+from fastapi import FastAPI, HTTPException, Request
+
+_SECRET = os.environ.get("SKILLSET_SECRET", "secret")
+app = FastAPI()
+
+
+def verify_signature(body: bytes, signature: str, secret: str = _SECRET) -> bool:
+    """Verify an HMAC signature for ``body`` using ``secret``."""
+    expected = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+    return hmac.compare_digest(signature, expected)
+
+
+@app.post("/search/issues")
+async def search_issues_skill(request: Request) -> Dict[str, List[Dict[str, Any]]]:
+    """Search a static set of issues.
+
+    The request body must contain ``{"query": "..."}`` and include an
+    ``X-Signature`` header with an HMAC SHA256 digest of the raw body.
+    """
+    body = await request.body()
+    signature = request.headers.get("x-signature", "")
+    if not verify_signature(body, signature):
+        raise HTTPException(status_code=401, detail="invalid signature")
+
+    payload = json.loads(body.decode())
+    query = payload.get("query", "").lower()
+    issues = [
+        {"id": 1, "title": "Login bug"},
+        {"id": 2, "title": "Dark mode feature"},
+        {"id": 3, "title": "Docs update"},
+    ]
+    matches = [issue for issue in issues if query in issue["title"].lower()]
+    return {"issues": matches}
+
+
+if __name__ == "__main__":  # pragma: no cover - manual run helper
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8001)

--- a/tests/runtime/test_backend_mcp_server.py
+++ b/tests/runtime/test_backend_mcp_server.py
@@ -1,0 +1,15 @@
+from backend.mcp_server import fetch, search
+import pytest
+import asyncio
+
+
+@pytest.mark.asyncio
+async def test_search_and_fetch_tools() -> None:
+    results = await search("dark")
+    assert results == ["2"]
+
+    data = await fetch("2")
+    assert data["title"] == "Add dark mode"
+
+    with pytest.raises(KeyError):
+        await fetch("999")

--- a/tests/runtime/test_backend_skillset_server.py
+++ b/tests/runtime/test_backend_skillset_server.py
@@ -1,0 +1,36 @@
+import hmac
+import hashlib
+import json
+
+from fastapi.testclient import TestClient
+
+from backend.skillset_server import app, verify_signature
+
+
+def _sign(body: bytes, secret: str = "secret") -> str:
+    return hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
+
+def test_verify_signature() -> None:
+    body = b"{}"
+    sig = _sign(body)
+    assert verify_signature(body, sig)
+    assert not verify_signature(body, "bad")
+
+
+def test_search_issues_skill() -> None:
+    client = TestClient(app)
+    payload = {"query": "dark"}
+    body = json.dumps(payload).encode()
+    headers = {"x-signature": _sign(body)}
+    resp = client.post("/search/issues", data=body, headers=headers)
+    assert resp.status_code == 200
+    issues = resp.json()["issues"]
+    assert issues == [{"id": 2, "title": "Dark mode feature"}]
+
+
+def test_search_issues_skill_bad_signature() -> None:
+    client = TestClient(app)
+    payload = {"query": "dark"}
+    resp = client.post("/search/issues", json=payload, headers={"x-signature": "bad"})
+    assert resp.status_code == 401


### PR DESCRIPTION
## Summary
- add simple MCP server with search and fetch tools
- expose FastAPI skillset server with `search_issues_skill` and HMAC verification
- wire Makefile targets to run the new services

## What changed / Why
- enables local experimentation with a minimal MCP backend and a signed skillset endpoint
- Makefile helpers streamline running both services during development

## Risks
- new servers are minimal; further hardening may be required before production use

## Test coverage
- added unit tests for MCP `search`/`fetch` and skillset signature handling

## Verification
- `pre-commit run --all-files` (passed)
- `pytest -q tests/runtime` (fails: SyntaxError in existing tests, see logs)

## Runtime impact
- introduces optional backend services; no impact on main runtime unless used

## Observability
- servers log through FastAPI/MCP defaults; no new telemetry fields

## Rollback
- revert commit `[backend] add MCP and skillset servers`


------
https://chatgpt.com/codex/tasks/task_e_68ad279c32e4832881a8e5dccb624dc1