### PR TITLE
[planner] refine parallelization policy

### DIFF
--- a/cortex/planner/parallel_wrapper.py
+++ b/cortex/planner/parallel_wrapper.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from typing import Sequence
+
+
+def _have_shared_dependencies(substeps: Sequence[object]) -> bool:
+    """Return True if any substeps share a tool dependency."""
+    seen: set[str] = set()
+    for step in substeps:
+        tool = getattr(step, "tool", None) or getattr(step, "tool_hint", None)
+        if tool is None:
+            continue
+        if tool in seen:
+            return True
+        seen.add(tool)
+    return False
+
+
+def _estimate_total_time(substeps: Sequence[object]) -> float:
+    """Estimate the total sequential execution time for substeps."""
+    return float(sum(getattr(step, "estimated_time", 0.0) or 0.0 for step in substeps))
+
+
+def _estimate_parallel_time(substeps: Sequence[object]) -> float:
+    """Estimate execution time if substeps run in parallel."""
+    times = [getattr(step, "estimated_time", 0.0) or 0.0 for step in substeps]
+    return float(max(times) if times else 0.0)
+
+
+def should_parallelize(
+    substeps: Sequence[object],
+    *,
+    parallel_threshold: int = 2,
+    min_parallel_benefit: float = 0.0,
+) -> bool:
+    """Determine if substeps should execute in parallel.
+
+    Parallelization is permitted only when all conditions are met:
+    - Number of substeps exceeds ``parallel_threshold``
+    - Substeps do not share tool dependencies
+    - Expected time savings exceed ``min_parallel_benefit``
+    """
+
+    if len(substeps) <= parallel_threshold:
+        return False
+
+    if _have_shared_dependencies(substeps):
+        return False
+
+    sequential_time = _estimate_total_time(substeps)
+    parallel_time = _estimate_parallel_time(substeps)
+    benefit = sequential_time - parallel_time
+    return benefit > min_parallel_benefit

--- a/tests/planner/test_parallel_policy.py
+++ b/tests/planner/test_parallel_policy.py
@@ -1,0 +1,51 @@
+from dataclasses import dataclass
+
+from cortex.planner.parallel_wrapper import should_parallelize
+
+@dataclass
+class Step:
+    estimated_time: float
+    tool: str | None = None
+
+
+def test_parallelization_when_conditions_met():
+    substeps = [
+        Step(estimated_time=5, tool="a"),
+        Step(estimated_time=4, tool="b"),
+        Step(estimated_time=6, tool="c"),
+    ]
+    assert should_parallelize(
+        substeps, parallel_threshold=2, min_parallel_benefit=3
+    )
+
+
+def test_no_parallelization_with_shared_dependencies():
+    substeps = [
+        Step(estimated_time=5, tool="a"),
+        Step(estimated_time=4, tool="a"),
+        Step(estimated_time=6, tool="b"),
+    ]
+    assert not should_parallelize(
+        substeps, parallel_threshold=2, min_parallel_benefit=3
+    )
+
+
+def test_no_parallelization_when_threshold_not_met():
+    substeps = [
+        Step(estimated_time=5, tool="a"),
+        Step(estimated_time=4, tool="b"),
+    ]
+    assert not should_parallelize(
+        substeps, parallel_threshold=2, min_parallel_benefit=3
+    )
+
+
+def test_no_parallelization_when_benefit_insufficient():
+    substeps = [
+        Step(estimated_time=1, tool="a"),
+        Step(estimated_time=1, tool="b"),
+        Step(estimated_time=1, tool="c"),
+    ]
+    assert not should_parallelize(
+        substeps, parallel_threshold=2, min_parallel_benefit=5
+    )


### PR DESCRIPTION
## Summary
- add parallelization policy with dependency and time checks
- test parallelization decision scenarios

## What changed / Why
- ensure parallelization only when tasks are independent and worthwhile
- add tests covering threshold, dependency overlap, and benefit calculation

## Risks
- inaccurate time estimates may still lead to suboptimal scheduling

## Test coverage
- `tests/planner/test_parallel_policy.py`

## Verification
- `pre-commit run --all-files` *(fails: .vscode/keybindings.json invalid JSON; no-debug-statements hook error)*
- `pytest -q tests/planner/test_parallel_policy.py tests/runtime` *(fails: ImportError: cannot import name 'FixtureDef' from 'pytest')*

## Runtime impact
- minimal; lightweight checks before spawning parallel tasks

## Observability
- no new telemetry added

## Rollback
- revert commits `[planner] refine parallelization policy` and `[tests] cover parallelization policy`


------
https://chatgpt.com/codex/tasks/task_e_68ae561565748328b01c8eead0794f59