### PR TITLE
[planner] Add telemetry timing

### DIFF
--- a/cortex/planner/parallel_wrapper.py
+++ b/cortex/planner/parallel_wrapper.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Awaitable, Callable, Iterable, Any
+
+# Simple telemetry hook; tests monkeypatch this
+TELEMETRY_EVENTS: list[dict[str, Any]] = []
+
+
+def _emit_telemetry(mode: str, steps: int, duration: float, success: bool) -> None:
+    """Internal helper to emit telemetry events."""
+    TELEMETRY_EVENTS.append(
+        {
+            "mode": mode,
+            "steps": steps,
+            "duration": duration,
+            "success": success,
+        }
+    )
+
+
+async def decide_and_run(
+    tasks: Iterable[Callable[[], Awaitable[Any]]], *, parallel: bool = True
+) -> None:
+    """Execute tasks either in parallel or sequentially.
+
+    Telemetry is emitted indicating execution mode, step count, duration,
+    and whether execution succeeded.
+    """
+    functions = list(tasks)
+    mode = "parallel" if parallel else "sequential"
+    start = time.perf_counter()
+    success = False
+    try:
+        if parallel:
+            await asyncio.gather(*(fn() for fn in functions))
+        else:
+            for fn in functions:
+                await fn()
+    except Exception:
+        success = False
+        raise
+    else:
+        success = True
+    finally:
+        duration = time.perf_counter() - start
+        _emit_telemetry(mode, len(functions), duration, success)

--- a/tests/planner/test_parallel_wrapper.py
+++ b/tests/planner/test_parallel_wrapper.py
@@ -1,0 +1,64 @@
+import pytest
+
+from cortex.planner import parallel_wrapper
+
+
+async def _noop():
+    return None
+
+
+async def _fail():
+    raise RuntimeError("boom")
+
+
+@pytest.mark.asyncio
+async def test_emits_telemetry_parallel_success(monkeypatch):
+    events = []
+
+    def record(mode: str, steps: int, duration: float, success: bool) -> None:
+        events.append(
+            {
+                "mode": mode,
+                "steps": steps,
+                "duration": duration,
+                "success": success,
+            }
+        )
+
+    monkeypatch.setattr(parallel_wrapper, "_emit_telemetry", record)
+
+    await parallel_wrapper.decide_and_run([_noop, _noop], parallel=True)
+
+    assert events
+    event = events[0]
+    assert event["mode"] == "parallel"
+    assert event["steps"] == 2
+    assert event["success"] is True
+    assert event["duration"] >= 0
+
+
+@pytest.mark.asyncio
+async def test_emits_telemetry_sequential_failure(monkeypatch):
+    events = []
+
+    def record(mode: str, steps: int, duration: float, success: bool) -> None:
+        events.append(
+            {
+                "mode": mode,
+                "steps": steps,
+                "duration": duration,
+                "success": success,
+            }
+        )
+
+    monkeypatch.setattr(parallel_wrapper, "_emit_telemetry", record)
+
+    with pytest.raises(RuntimeError):
+        await parallel_wrapper.decide_and_run([_noop, _fail], parallel=False)
+
+    assert events
+    event = events[0]
+    assert event["mode"] == "sequential"
+    assert event["steps"] == 2
+    assert event["success"] is False
+    assert event["duration"] >= 0


### PR DESCRIPTION
## Summary
- add new parallel_wrapper with telemetry around task execution
- test telemetry events for parallel success and sequential failure

## What changed / Why
- ensure decide_and_run captures execution duration and success status for observability

## Risks
- minimal: new module used only in planner wrappers

## Test coverage
- added tests/planner/test_parallel_wrapper.py verifying telemetry for success and failure

## Verification
- `pre-commit run --files cortex/planner/parallel_wrapper.py tests/planner/test_parallel_wrapper.py` *(fails: no-debug-statements)*
- `pytest -q tests/planner/test_parallel_wrapper.py` *(fails: ImportError: cannot import name 'FixtureDef' from 'pytest')*
- `pytest -q tests/runtime` *(fails: ImportError: cannot import name 'FixtureDef' from 'pytest')*

## Runtime impact
- adds lightweight timing around task execution

## Observability
- emits telemetry with mode, steps, duration, success flag

## Rollback
- revert this commit

------
https://chatgpt.com/codex/tasks/task_e_68ae56294c548328b483b11ea5c9badb