### PR TITLE
[runtime] add langchain runnable fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Production-ready architecture with:
 - Real-time telemetry broadcasting via MCP
 - Automatic LLM fallback (Gemini -> local Super Alita -> mock) with telemetry events
 - Direct local Hugging Face model loading (`LLM_MODEL=hf:<model_id>`)
+- Optional LangChain runnable support via `reug_runtime.adapter` with local fallbacks
 
 ## Quick Start
 
@@ -110,7 +111,7 @@ To use VS Code Insiders with GPT-OSS hosted by Ollama (streamlined setup):
 
 ### Usage in VS Code Insiders
 
-- **Direct Ollama**: Command palette → `Alita: Invoke Agent (Ollama)` 
+- **Direct Ollama**: Command palette → `Alita: Invoke Agent (Ollama)`
   - Uses your local Ollama directly with model `gpt-oss:20b` (configured as default)
   - Streams response to a new Markdown document
 

--- a/src/reug_runtime/adapter.py
+++ b/src/reug_runtime/adapter.py
@@ -1,0 +1,74 @@
+"""Optional LangChain runnable compatibility layer.
+
+This module attempts to import lightweight "Runnable" helpers from
+``langchain_core``. When the dependency is unavailable, it falls back to
+minimal local implementations so calling code can continue to operate.
+"""
+from __future__ import annotations
+
+from typing import Any, Callable, Iterable
+
+try:  # pragma: no cover - optional dependency
+    from langchain_core.runnables import RunnableLambda as _LCRunnableLambda
+    from langchain_core.runnables import RunnableSequence as _LCRunnableSequence
+    HAS_LANGCHAIN = True
+except Exception:  # pragma: no cover - no langchain at runtime
+    _LCRunnableLambda = None  # type: ignore[assignment]
+    _LCRunnableSequence = None  # type: ignore[assignment]
+    HAS_LANGCHAIN = False
+
+
+class LocalRunnableLambda:
+    """Simple callable wrapper mirroring LangChain's RunnableLambda."""
+
+    def __init__(self, func: Callable[[Any], Any]) -> None:
+        self._func = func
+
+    def invoke(self, input_: Any) -> Any:
+        return self._func(input_)
+
+
+class LocalRunnableSequence:
+    """Sequentially execute contained runnables."""
+
+    def __init__(self, steps: Iterable[Any]) -> None:
+        self._steps = list(steps)
+
+    def invoke(self, input_: Any) -> Any:
+        value = input_
+        for step in self._steps:
+            value = step.invoke(value)
+        return value
+
+
+def runnable_lambda(func: Callable[[Any], Any]) -> Any:
+    """Factory returning a runnable lambda.
+
+    Uses LangChain's implementation when available; otherwise returns a
+    lightweight local version.
+    """
+
+    if HAS_LANGCHAIN and _LCRunnableLambda:
+        return _LCRunnableLambda(func)
+    return LocalRunnableLambda(func)
+
+
+def runnable_sequence(steps: Iterable[Any]) -> Any:
+    """Factory returning a runnable sequence.
+
+    Uses LangChain's implementation when available; otherwise returns a
+    lightweight local version.
+    """
+
+    if HAS_LANGCHAIN and _LCRunnableSequence:
+        return _LCRunnableSequence(steps)
+    return LocalRunnableSequence(steps)
+
+
+__all__ = [
+    "HAS_LANGCHAIN",
+    "runnable_lambda",
+    "runnable_sequence",
+    "LocalRunnableLambda",
+    "LocalRunnableSequence",
+]

--- a/tests/runtime/test_langchain_adapter_fallback.py
+++ b/tests/runtime/test_langchain_adapter_fallback.py
@@ -1,0 +1,14 @@
+import pytest
+
+from src.reug_runtime import adapter
+
+
+def test_local_runnable_fallback(monkeypatch):
+    """When HAS_LANGCHAIN is False, factories return local implementations."""
+    monkeypatch.setattr(adapter, "HAS_LANGCHAIN", False)
+    add_one = adapter.runnable_lambda(lambda x: x + 1)
+    times_two = adapter.runnable_lambda(lambda x: x * 2)
+    seq = adapter.runnable_sequence([add_one, times_two])
+    assert isinstance(add_one, adapter.LocalRunnableLambda)
+    assert isinstance(seq, adapter.LocalRunnableSequence)
+    assert seq.invoke(3) == 8


### PR DESCRIPTION
## Summary
- add optional LangChain runnable compatibility layer with local fallbacks
- document adapter fallback in README
- cover fallback with targeted runtime test

## What changed / Why
- enables runtime to operate when LangChain is unavailable via `HAS_LANGCHAIN` flag and stub runnables

## Risks
- minimal: new adapter factories add small abstraction layer

## Test coverage
- added `tests/runtime/test_langchain_adapter_fallback.py` to verify local runnable execution when LangChain is missing

## Verification
- `pre-commit run --files README.md src/reug_runtime/adapter.py tests/runtime/test_langchain_adapter_fallback.py` *(fails: No Debug Statements hook)*
- `pytest -q tests/runtime` *(fails: SyntaxError in existing tests)*
- `pytest -q tests/runtime/test_langchain_adapter_fallback.py`

## Runtime impact
- no measurable latency impact; factories choose LangChain or local classes at import time

## Observability
- none added; existing telemetry unaffected

## Rollback
- revert commit `[runtime] add langchain runnable fallback`

------
https://chatgpt.com/codex/tasks/task_e_68ae56f2cc508328941487f0a769d7b2