### PR TITLE
mcp: add telemetry timing

### DIFF
--- a/mcp_server_wrapper.py
+++ b/mcp_server_wrapper.py
@@ -223,7 +223,7 @@ class MCPBridge:
 
     def _create_mcp_executor(self, name: str):
         async def _exec(**kwargs):
-            return await self.mcp_registry.invoke(name, kwargs)
+            return await self.mcp_registry.ainvoke(name, kwargs)
 
         return _exec
 

--- a/src/mcp_local/registry.py
+++ b/src/mcp_local/registry.py
@@ -2,9 +2,21 @@
 
 from __future__ import annotations
 
+import asyncio
+import time
 from collections.abc import Awaitable, Callable
 from pathlib import Path
 from typing import Any
+
+try:  # pragma: no cover - telemetry optional
+    from cortex import telemetry  # type: ignore
+except Exception:  # pragma: no cover - fallback when cortex not installed
+    class _Telemetry:
+        @staticmethod
+        def emit(*args: Any, **kwargs: Any) -> None:
+            """No-op telemetry emitter."""
+
+    telemetry = _Telemetry()
 
 ToolFunc = Callable[..., Awaitable[Any]]
 
@@ -46,23 +58,37 @@ class ToolRegistry:
             raise ValueError(f"No callable '{name}' found in provided code")
         self.register(name, fn)  # type: ignore[arg-type]
 
-    async def invoke(self, name: str, args: dict[str, Any]) -> Any:
-        """Invoke a registered tool.
+    async def _timed_invoke(self, name: str, args: dict[str, Any]) -> Any:
+        """Execute a tool with timing and telemetry."""
+        start = time.perf_counter()
+        success = True
+        try:
+            if name not in self._tools:
+                success = False
+                raise KeyError(name)
+            return await self._tools[name](**args)
+        except Exception:
+            success = False
+            raise
+        finally:
+            duration_ms = (time.perf_counter() - start) * 1000
+            try:
+                telemetry.emit(
+                    "tool_invocation",
+                    tool=name,
+                    duration_ms=duration_ms,
+                    success=success,
+                )
+            except Exception:  # pragma: no cover - telemetry failures ignored
+                pass
 
-        Args:
-            name: Registered tool name.
-            args: Argument dictionary passed to the tool.
+    async def ainvoke(self, name: str, args: dict[str, Any]) -> Any:
+        """Asynchronously invoke a registered tool with telemetry."""
+        return await self._timed_invoke(name, args)
 
-        Returns:
-            Any: Result from the tool.
-
-        Raises:
-            KeyError: If the tool is not registered.
-        """
-
-        if name not in self._tools:
-            raise KeyError(name)
-        return await self._tools[name](**args)
+    def invoke(self, name: str, args: dict[str, Any]) -> Any:
+        """Synchronously invoke a registered tool with telemetry."""
+        return asyncio.run(self._timed_invoke(name, args))
 
     def list_tools(self) -> list[str]:
         """Return the names of all registered tools."""

--- a/src/mcp_local/server.py
+++ b/src/mcp_local/server.py
@@ -127,8 +127,8 @@ async def execute_tool(request: ToolExecutionRequest) -> ToolExecutionResponse:
         raise HTTPException(status_code=404, detail=f"Tool '{tool_name}' not found")
 
     try:
-        # Execute tool using invoke
-        result = await registry.invoke(tool_name, params)
+        # Execute tool using ainvoke
+        result = await registry.ainvoke(tool_name, params)
     except Exception as e:
         logger.exception("Error executing tool")  # exception already includes traceback
         return ToolExecutionResponse(tool_name=tool_name, success=False, error=str(e))

--- a/src/super_alita_mcp/fastapi_server.py
+++ b/src/super_alita_mcp/fastapi_server.py
@@ -127,8 +127,8 @@ async def execute_tool(request: ToolExecutionRequest) -> ToolExecutionResponse:
         raise HTTPException(status_code=404, detail=f"Tool '{tool_name}' not found")
 
     try:
-        # Execute tool using invoke
-        result = await registry.invoke(tool_name, params)
+        # Execute tool using ainvoke
+        result = await registry.ainvoke(tool_name, params)
     except Exception as e:
         logger.exception("Error executing tool")  # exception already includes traceback
         return ToolExecutionResponse(tool_name=tool_name, success=False, error=str(e))

--- a/src/super_alita_mcp/registry.py
+++ b/src/super_alita_mcp/registry.py
@@ -2,9 +2,21 @@
 
 from __future__ import annotations
 
+import asyncio
+import time
 from collections.abc import Awaitable, Callable
 from pathlib import Path
 from typing import Any
+
+try:  # pragma: no cover - telemetry optional
+    from cortex import telemetry  # type: ignore
+except Exception:  # pragma: no cover - fallback when cortex not installed
+    class _Telemetry:
+        @staticmethod
+        def emit(*args: Any, **kwargs: Any) -> None:
+            """No-op telemetry emitter."""
+
+    telemetry = _Telemetry()
 
 ToolFunc = Callable[..., Awaitable[Any]]
 
@@ -46,23 +58,37 @@ class ToolRegistry:
             raise ValueError(f"No callable '{name}' found in provided code")
         self.register(name, fn)  # type: ignore[arg-type]
 
-    async def invoke(self, name: str, args: dict[str, Any]) -> Any:
-        """Invoke a registered tool.
+    async def _timed_invoke(self, name: str, args: dict[str, Any]) -> Any:
+        """Execute a tool with timing and telemetry."""
+        start = time.perf_counter()
+        success = True
+        try:
+            if name not in self._tools:
+                success = False
+                raise KeyError(name)
+            return await self._tools[name](**args)
+        except Exception:
+            success = False
+            raise
+        finally:
+            duration_ms = (time.perf_counter() - start) * 1000
+            try:
+                telemetry.emit(
+                    "tool_invocation",
+                    tool=name,
+                    duration_ms=duration_ms,
+                    success=success,
+                )
+            except Exception:  # pragma: no cover - ignore telemetry failures
+                pass
 
-        Args:
-            name: Registered tool name.
-            args: Argument dictionary passed to the tool.
+    async def ainvoke(self, name: str, args: dict[str, Any]) -> Any:
+        """Asynchronously invoke a registered tool with telemetry."""
+        return await self._timed_invoke(name, args)
 
-        Returns:
-            Any: Result from the tool.
-
-        Raises:
-            KeyError: If the tool is not registered.
-        """
-
-        if name not in self._tools:
-            raise KeyError(name)
-        return await self._tools[name](**args)
+    def invoke(self, name: str, args: dict[str, Any]) -> Any:
+        """Synchronously invoke a registered tool with telemetry."""
+        return asyncio.run(self._timed_invoke(name, args))
 
     def list_tools(self) -> list[str]:
         """Return the names of all registered tools."""

--- a/tests/test_tool_registry_telemetry.py
+++ b/tests/test_tool_registry_telemetry.py
@@ -1,0 +1,73 @@
+import pytest
+
+from src.mcp_local import registry as registry_module
+
+import pytest
+
+from src.mcp_local import registry as registry_module
+
+
+class TelemetryRecorder:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, dict]] = []
+
+    def emit(self, event: str, **data: object) -> None:
+        self.events.append((event, data))
+
+
+@pytest.mark.asyncio
+async def test_ainvoke_emits_telemetry(monkeypatch: pytest.MonkeyPatch) -> None:
+    registry = registry_module.ToolRegistry()
+
+    async def plus_one(x: int) -> int:
+        return x + 1
+
+    registry.register("plus_one", plus_one)
+    recorder = TelemetryRecorder()
+    monkeypatch.setattr(registry_module.telemetry, "emit", recorder.emit)
+
+    result = await registry.ainvoke("plus_one", {"x": 1})
+    assert result == 2
+
+    assert recorder.events
+    name, data = recorder.events[0]
+    assert name == "tool_invocation"
+    assert data["tool"] == "plus_one"
+    assert data["success"] is True
+    assert isinstance(data["duration_ms"], float)
+
+
+@pytest.mark.asyncio
+async def test_ainvoke_failure_emits_telemetry(monkeypatch: pytest.MonkeyPatch) -> None:
+    registry = registry_module.ToolRegistry()
+    recorder = TelemetryRecorder()
+    monkeypatch.setattr(registry_module.telemetry, "emit", recorder.emit)
+
+    with pytest.raises(KeyError):
+        await registry.ainvoke("missing", {})
+
+    assert recorder.events
+    name, data = recorder.events[0]
+    assert name == "tool_invocation"
+    assert data["tool"] == "missing"
+    assert data["success"] is False
+
+
+def test_invoke_sync_emits_telemetry(monkeypatch: pytest.MonkeyPatch) -> None:
+    registry = registry_module.ToolRegistry()
+
+    async def foo() -> str:
+        return "ok"
+
+    registry.register("foo", foo)
+    recorder = TelemetryRecorder()
+    monkeypatch.setattr(registry_module.telemetry, "emit", recorder.emit)
+
+    result = registry.invoke("foo", {})
+    assert result == "ok"
+
+    assert recorder.events
+    name, data = recorder.events[0]
+    assert name == "tool_invocation"
+    assert data["tool"] == "foo"
+    assert data["success"] is True


### PR DESCRIPTION
## Summary
- track tool durations with telemetry in MCP registries
- call async ainvoke API from MCP servers
- add tests for telemetry emission

## Testing
- `SKIP=no-debug-statements pre-commit run --files src/mcp_local/registry.py src/super_alita_mcp/registry.py src/mcp_local/server.py src/super_alita_mcp/fastapi_server.py mcp_server_wrapper.py tests/test_tool_registry_telemetry.py`
- `pre-commit run no-debug-statements --all-files`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/test_tool_registry_telemetry.py tests/runtime` *(fails: tests/runtime/test_router_circuit_breaker.py, tests/runtime/test_router_result_cap.py)*

------
https://chatgpt.com/codex/tasks/task_e_68ae56f3940083289c8f052ea2b5e139