### PR TITLE
runtime: validate tool kwargs before invocation

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -11,6 +11,7 @@ import json
 import logging
 import os
 import sys
+import inspect
 from collections.abc import AsyncGenerator, Callable
 from logging.config import dictConfig
 from pathlib import Path
@@ -161,6 +162,12 @@ class SimpleAbilityRegistry:
                 "output_schema": {"type": "object"},
             }
         }
+        # Tool implementations keyed by name
+        class _EchoTool:
+            async def aexecute(self, payload: str) -> dict[str, Any]:
+                return {"echo": payload}
+
+        self._impls: dict[str, Any] = {"echo": _EchoTool()}
 
     def get_available_tools_schema(self) -> list[dict[str, Any]]:
         return list(self._contracts.values())
@@ -182,13 +189,26 @@ class SimpleAbilityRegistry:
         tid = contract["tool_id"]
         self._contracts[tid] = contract
         self._known.add(tid)
+        # Default implementation accepts any kwargs
+        self._impls.setdefault(tid, lambda **kwargs: {"ok": True, "tool": tid, "args": kwargs})
 
     async def execute(self, tool_name: str, args: dict[str, Any]) -> dict[str, Any]:
-        # Implement your actual bindings here (MCP, HTTP APIs, Python functions).
-        if tool_name == "echo":
-            return {"echo": args.get("payload", "")}
-        # Fallback generic
-        return {"ok": True, "tool": tool_name, "args": args}
+        impl = self._impls.get(tool_name)
+        if impl is None:
+            return {"ok": True, "tool": tool_name, "args": args}
+        fn = getattr(impl, "aexecute", None) or getattr(impl, "run", None) or impl
+        sig = inspect.signature(fn)
+        params = sig.parameters
+        accepts_var_kw = any(p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values())
+        unexpected = [k for k in args if k not in params] if not accepts_var_kw else []
+        if unexpected:
+            raise TypeError(
+                f"Unexpected argument(s): {', '.join(sorted(unexpected))} for tool '{tool_name}'"
+            )
+        filtered = {k: v for k, v in args.items() if accepts_var_kw or k in params}
+        if inspect.iscoroutinefunction(fn):
+            return await fn(**filtered)
+        return fn(**filtered)
 
 
 # --- Knowledge graph (minimal; replace with your store/driver) ---

--- a/tests/runtime/fakes.py
+++ b/tests/runtime/fakes.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 from collections.abc import AsyncGenerator
+import inspect
 from typing import Any
 
 
@@ -19,6 +20,11 @@ class FakeAbilityRegistry:
     def __init__(self) -> None:
         self._known = {"echo"}
         self._calls: list[dict[str, Any]] = []
+        class _EchoTool:
+            async def aexecute(self, payload: str) -> dict[str, str]:
+                return {"echo": payload}
+
+        self._impls: dict[str, Any] = {"echo": _EchoTool()}
 
     def get_available_tools_schema(self) -> list[dict[str, Any]]:
         return [
@@ -49,14 +55,28 @@ class FakeAbilityRegistry:
         return True
 
     async def register(self, contract: dict[str, Any]) -> None:
-        self._known.add(contract["tool_id"])
+        tid = contract["tool_id"]
+        self._known.add(tid)
+        self._impls.setdefault(tid, lambda **kwargs: {"ok": True, "args": kwargs})
 
     async def execute(self, tool_name: str, args: dict[str, Any]) -> dict[str, Any]:
         self._calls.append({"tool": tool_name, "args": dict(args)})
-        if tool_name == "echo":
-            return {"echo": args["payload"]}
-        # default fallback for dynamically-added tools
-        return {"ok": True, "args": args}
+        impl = self._impls.get(tool_name)
+        if impl is None:
+            return {"ok": True, "args": args}
+        fn = getattr(impl, "aexecute", None) or getattr(impl, "run", None) or impl
+        sig = inspect.signature(fn)
+        params = sig.parameters
+        accepts_var_kw = any(p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values())
+        unexpected = [k for k in args if k not in params] if not accepts_var_kw else []
+        if unexpected:
+            raise TypeError(
+                f"Unexpected argument(s): {', '.join(sorted(unexpected))} for tool '{tool_name}'"
+            )
+        filtered = {k: v for k, v in args.items() if accepts_var_kw or k in params}
+        if inspect.iscoroutinefunction(fn):
+            return await fn(**filtered)
+        return fn(**filtered)
 
 
 class FakeKG:

--- a/tests/runtime/test_registry_arg_validation.py
+++ b/tests/runtime/test_registry_arg_validation.py
@@ -1,0 +1,10 @@
+import pytest
+
+from tests.runtime.fakes import FakeAbilityRegistry
+
+
+@pytest.mark.asyncio
+async def test_execute_rejects_unexpected_kwargs() -> None:
+    reg = FakeAbilityRegistry()
+    with pytest.raises(TypeError, match="Unexpected argument\(s\): extra"):
+        await reg.execute("echo", {"payload": "hi", "extra": 1})


### PR DESCRIPTION
## Summary
- ensure ability registry inspects tool signatures and rejects unexpected kwargs
- add regression test for extraneous argument handling

## What changed / Why
- filtering kwargs against aexecute/run signatures prevents silent integration bugs

## Risks
- minor overhead from inspecting signatures per call

## Test coverage
- `tests/runtime/test_registry_arg_validation.py`

## Verification
- `pre-commit run --files src/main.py tests/runtime/fakes.py tests/runtime/test_registry_arg_validation.py` (fails: no-debug-statements)
- `pytest -q tests/runtime/test_registry_arg_validation.py` (ImportError: FixtureDef)

## Runtime impact
- negligible; single signature lookup per tool call

## Observability
- none added

## Rollback
- revert commits `[runtime] validate tool kwargs` and `[tests] cover extraneous kwargs`


------
https://chatgpt.com/codex/tasks/task_e_68ae56f4d32083289c13fee5a63acdf8