### PR TITLE
tools: gracefully handle runnable errors

### DIFF
--- a/tests/tools/test_langchain_adapter.py
+++ b/tests/tools/test_langchain_adapter.py
@@ -1,0 +1,27 @@
+import pytest
+
+from tools.langchain_adapter import AlitaToolRunnable
+
+
+class AsyncFailingTool:
+    async def aexecute(self, **_: object) -> None:
+        raise RuntimeError("async boom")
+
+
+class SyncFailingTool:
+    def run(self, **_: object) -> None:
+        raise RuntimeError("sync boom")
+
+
+@pytest.mark.asyncio
+async def test_ainvoke_handles_async_failure() -> None:
+    runnable = AlitaToolRunnable(AsyncFailingTool())
+    result = await runnable.ainvoke({})
+    assert result == {"error": "async boom", "success": False}
+
+
+@pytest.mark.asyncio
+async def test_ainvoke_handles_sync_failure() -> None:
+    runnable = AlitaToolRunnable(SyncFailingTool())
+    result = await runnable.ainvoke({})
+    assert result == {"error": "sync boom", "success": False}

--- a/tools/langchain_adapter.py
+++ b/tools/langchain_adapter.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+"""LangChain adapter utilities for Super Alita tools."""
+
+import inspect
+from typing import Any
+
+
+class AlitaToolRunnable:
+    """Minimal runnable wrapper around tools.
+
+    The wrapper calls either ``aexecute`` (async) or ``run`` (sync) on the
+    provided ``tool`` and gracefully captures any errors so downstream chains
+    can handle them without exceptions leaking through.
+    """
+
+    def __init__(self, tool: Any) -> None:
+        self.tool = tool
+
+    async def ainvoke(
+        self, input: dict[str, Any] | None = None, config: Any | None = None
+    ) -> Any:
+        """Invoke the underlying tool safely.
+
+        Parameters
+        ----------
+        input:
+            Optional dictionary of inputs to pass to the tool.
+        config:
+            Optional invocation configuration (unused).
+        """
+
+        input = input or {}
+        try:
+            if hasattr(self.tool, "aexecute"):
+                return await self.tool.aexecute(**input)
+            if hasattr(self.tool, "run"):
+                result = self.tool.run(**input)
+                if inspect.isawaitable(result):
+                    result = await result
+                return result
+            raise AttributeError("Tool does not implement aexecute or run")
+        except Exception as e:  # pragma: no cover - defensive
+            return {"error": str(e), "success": False}


### PR DESCRIPTION
## Summary
- ensure AlitaToolRunnable returns structured errors instead of raising
- test asynchronous and synchronous failing tools

## Testing
- `pre-commit run --all-files` (failed: Extension TypeScript Compilation interrupted)
- `pytest -q tests/tools/test_langchain_adapter.py`
- `pytest -q tests/runtime` (failed: ImportError: FixtureDef)


------
https://chatgpt.com/codex/tasks/task_e_68ae56f15c0883289429c624f5acc70c