### PR TITLE
adapters: raise NotImplementedError in LangChain fallback

### DIFF
--- a/src/adapters/__init__.py
+++ b/src/adapters/__init__.py
@@ -1,0 +1,1 @@
+"""Adapters package for third-party integrations."""

--- a/src/adapters/langchain_adapter.py
+++ b/src/adapters/langchain_adapter.py
@@ -1,0 +1,18 @@
+"""LangChain adapter fallback definitions."""
+
+from __future__ import annotations
+
+from typing import Any
+
+try:  # pragma: no cover - executed when LangChain is installed
+    from langchain_core.runnables import Runnable  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - executed when LangChain is missing
+    class Runnable:  # type: ignore[misc]
+        """Fallback `Runnable` when LangChain is unavailable."""
+
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            raise NotImplementedError("LangChain not installed")
+
+        def invoke(self, *args: Any, **kwargs: Any) -> Any:  # noqa: D401
+            """Mimic `Runnable.invoke` but always raises an error."""
+            raise NotImplementedError("LangChain not installed")

--- a/tests/adapters/test_langchain_adapter.py
+++ b/tests/adapters/test_langchain_adapter.py
@@ -1,0 +1,18 @@
+"""Tests for LangChain adapter fallbacks."""
+
+import pytest
+
+from src.adapters.langchain_adapter import Runnable
+
+
+def test_runnable_init_raises_not_implemented() -> None:
+    """Instantiating the fallback class should raise."""
+    with pytest.raises(NotImplementedError, match="LangChain not installed"):
+        Runnable()
+
+
+def test_runnable_invoke_raises_not_implemented() -> None:
+    """Calling `invoke` on a bypassed instance should raise."""
+    runnable = object.__new__(Runnable)
+    with pytest.raises(NotImplementedError, match="LangChain not installed"):
+        runnable.invoke()


### PR DESCRIPTION
## Summary
- raise `NotImplementedError` when LangChain `Runnable` fallback is used
- add regression test for fallback behavior

## What changed / Why
The LangChain adapter previously used ellipsis placeholders in its fallback `Runnable`, silently succeeding when the dependency was missing. Raising an explicit `NotImplementedError` provides clearer feedback to developers.

## Risks
- None; only affects environments without LangChain installed.

## Test coverage
- Added `tests/adapters/test_langchain_adapter.py` covering both constructor and `invoke` failure cases.

## Verification
- `pre-commit run --all-files` *(fails: no-debug-statements hook)*
- `pre-commit run --files src/adapters/__init__.py src/adapters/langchain_adapter.py tests/adapters/test_langchain_adapter.py` *(fails: no-debug-statements hook)*
- `pytest -q tests/adapters/test_langchain_adapter.py` *(passed)*
- `pytest -q tests/runtime` *(errors: syntax errors in existing tests)*

## Runtime impact
- None; only impacts error path when LangChain is absent.

## Observability
- No new telemetry or logging added.

## Rollback
- Revert this commit.

------
https://chatgpt.com/codex/tasks/task_e_68ae63ad65a083289adcf9078b8a311d