### PR TITLE
[telemetry] route MCP events through telemetry API

### DIFF
--- a/src/telemetry/mcp_broadcaster.py
+++ b/src/telemetry/mcp_broadcaster.py
@@ -151,9 +151,13 @@ class MCPTelemetryBroadcaster:
                 "metadata": event.metadata,
             }
 
-            # TODO: Implement actual MCP transmission
-            # For now, log to stderr so MCP server can capture it
-            print(f"TELEMETRY: {json.dumps(mcp_data)}", flush=True)
+            try:
+                from cortex.telemetry import emit as telemetry_emit
+            except Exception:
+                telemetry_emit = None
+
+            if telemetry_emit:
+                telemetry_emit(mcp_data)
 
         except Exception as e:
             logger.error(f"Failed to send event to MCP: {e}")

--- a/tests/runtime/test_mcp_broadcaster.py
+++ b/tests/runtime/test_mcp_broadcaster.py
@@ -1,30 +1,27 @@
-import json
+import sys
+import types
 
-import httpx
 import pytest
 
-from src.telemetry.mcp_broadcaster import MCPTelemetryBroadcaster
+from src.telemetry.mcp_broadcaster import MCPTelemetryBroadcaster, EventTypes
 
 
 @pytest.mark.asyncio
-async def test_broadcaster_posts_events(monkeypatch):
-    received: list[dict[str, object]] = []
-    auth_headers: list[str | None] = []
+async def test_broadcaster_uses_telemetry_api(monkeypatch) -> None:
+    emitted: list[dict] = []
+    telemetry_module = types.SimpleNamespace(emit=lambda evt: emitted.append(evt))
+    monkeypatch.setitem(sys.modules, "cortex.telemetry", telemetry_module)
 
-    def handler(request: httpx.Request) -> httpx.Response:
-        received.append(json.loads(request.content.decode()))
-        auth_headers.append(request.headers.get("Authorization"))
-        return httpx.Response(200)
-
-    transport = httpx.MockTransport(handler)
-    async with httpx.AsyncClient(transport=transport) as client:
-        monkeypatch.setenv("MCP_BROADCAST_URL", "https://mcp.test/telemetry")
-        monkeypatch.setenv("MCP_BROADCAST_TOKEN", "testtoken")
-        broadcaster = MCPTelemetryBroadcaster(http_client=client)
-        await broadcaster.start()
-        await broadcaster.broadcast_event("tool_call", "unit_test", {"foo": "bar"})
-        await broadcaster.stop()
-
-    tool_events = [e for e in received if e["event_type"] == "tool_call"]
-    assert tool_events and tool_events[0]["data"] == {"foo": "bar"}
-    assert any(h == "Bearer testtoken" for h in auth_headers)
+    broadcaster = MCPTelemetryBroadcaster()
+    await broadcaster.start()
+    await broadcaster.broadcast_event(
+        event_type=EventTypes.TOOL_CALL,
+        source="unit_test",
+        data={"a": 1},
+        session_id="sess",
+    )
+    assert emitted, "telemetry.emit was not called"
+    event = emitted[-1]
+    assert event["event_type"] == EventTypes.TOOL_CALL
+    assert event["source"] == "unit_test"
+    assert event["session_id"] == "sess"


### PR DESCRIPTION
## Summary
- use `cortex.telemetry.emit` in MCP broadcaster instead of printing
- cover telemetry emission with unit test

## Testing
- `pre-commit run --files src/telemetry/mcp_broadcaster.py tests/runtime/test_mcp_broadcaster.py` *(fails: mixed line ending hook rewrites file, no-debug-statements misconfigured)*
- `pytest -q tests/runtime` *(fails: ImportError: cannot import name 'FixtureDef' from 'pytest')*


------
https://chatgpt.com/codex/tasks/task_e_68ae63ae24ec83288771f8d22d8b5a6b