### PR TITLE
adapters: validate kwargs against target signature

### DIFF
--- a/src/adapters/__init__.py
+++ b/src/adapters/__init__.py
@@ -1,0 +1,1 @@
+"""Adapters package."""

--- a/src/adapters/langchain_adapter.py
+++ b/src/adapters/langchain_adapter.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import Any, Callable, TypeVar
+import inspect
+
+T = TypeVar("T")
+
+
+def validate_kwargs(func: Callable[..., Any], kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Ensure kwargs only contain parameters accepted by ``func``.
+
+    Raises:
+        TypeError: If ``kwargs`` contains keys not present in ``func``'s signature.
+    """
+    signature = inspect.signature(func)
+    allowed = set(signature.parameters.keys())
+    unexpected = set(kwargs) - allowed
+    if unexpected:
+        raise TypeError(
+            f"{func.__name__}() got unexpected keyword arguments: {sorted(unexpected)}"
+        )
+    return kwargs
+
+
+class LangChainAdapter:
+    """Simple adapter that validates kwargs before invocation."""
+
+    def invoke(self, func: Callable[..., T], **kwargs: Any) -> T:
+        """Call ``func`` ensuring keyword arguments match its signature."""
+        validate_kwargs(func, kwargs)
+        return func(**kwargs)

--- a/tests/adapters/__init__.py
+++ b/tests/adapters/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for adapters."""

--- a/tests/adapters/test_langchain_adapter.py
+++ b/tests/adapters/test_langchain_adapter.py
@@ -1,0 +1,18 @@
+import pytest
+
+from src.adapters.langchain_adapter import LangChainAdapter
+
+
+def sample_func(a: int, b: str) -> str:
+    return b * a
+
+
+def test_invoke_valid_kwargs():
+    adapter = LangChainAdapter()
+    assert adapter.invoke(sample_func, a=2, b="x") == "xx"
+
+
+def test_invoke_unexpected_kwargs_raises():
+    adapter = LangChainAdapter()
+    with pytest.raises(TypeError):
+        adapter.invoke(sample_func, a=2, b="x", c=1)


### PR DESCRIPTION
## Summary
- add `LangChainAdapter.validate_kwargs` to reject unexpected kwargs
- cover adapter invocation with unit tests

## What changed / Why
- ensure adapter detects invalid keyword arguments early by raising `TypeError`
- added simple adapter wrapper and tests to verify error propagation

## Risks
- new adapter module is unused elsewhere; integration points may still bypass validation

## Test coverage
- `tests/adapters/test_langchain_adapter.py`

## Verification
- `pre-commit run --files src/adapters/langchain_adapter.py tests/adapters/test_langchain_adapter.py` *(fails: missing pre_commit_hooks)*
- `pytest -q tests/runtime` *(fails: ImportError: cannot import name 'FixtureDef' from 'pytest')*
- `pytest -q tests/adapters/test_langchain_adapter.py` *(fails: ImportError: cannot import name 'FixtureDef' from 'pytest')*

## Runtime impact
- none; adapter not yet integrated into runtime

## Observability
- no new telemetry events added

## Rollback
- revert commit `[adapters] Validate kwargs`


------
https://chatgpt.com/codex/tasks/task_e_68ae63ae6b608328aafc72b9a9b8e0e3