### PR TITLE
adapters: validate langchain runnable input type

### DIFF
--- a/src/adapters/__init__.py
+++ b/src/adapters/__init__.py
@@ -1,0 +1,5 @@
+"""Adapters bridging external frameworks and Super Alita."""
+
+from .langchain_adapter import AlitaToolRunnable
+
+__all__ = ["AlitaToolRunnable"]

--- a/src/adapters/langchain_adapter.py
+++ b/src/adapters/langchain_adapter.py
@@ -1,0 +1,49 @@
+"""LangChain adapter utilities.
+
+This module exposes :class:`AlitaToolRunnable`, a lightweight wrapper that allows
+LangChain to call Super Alita tools.
+
+Input format
+------------
+The ``ainvoke`` method expects a dictionary mapping argument names to their
+values. For simple string input, supply ``{"input": "<text>"}``. Non-dict
+inputs raise :class:`TypeError`.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Awaitable, Callable, Optional
+
+
+class AlitaToolRunnable:
+    """Async runnable wrapper for Alita tools.
+
+    Parameters
+    ----------
+    tool:
+        Awaitable callable executed when invoking the runnable. The callable
+        must accept a single ``dict`` of arguments.
+    """
+
+    def __init__(self, tool: Callable[[dict[str, Any]], Awaitable[Any]]):
+        self._tool = tool
+
+    async def ainvoke(
+        self, input: Any, config: Optional[dict[str, Any]] = None
+    ) -> Any:
+        """Invoke the underlying tool asynchronously.
+
+        Parameters
+        ----------
+        input:
+            Dictionary of arguments for the tool. If the input is not a dict a
+            :class:`TypeError` is raised.
+        config:
+            Optional configuration passed through to the tool. Currently
+            unused.
+        """
+
+        if not isinstance(input, dict):
+            raise TypeError("AlitaToolRunnable expects dict input")
+
+        return await self._tool(input)

--- a/tests/runtime/test_langchain_adapter.py
+++ b/tests/runtime/test_langchain_adapter.py
@@ -1,0 +1,18 @@
+import asyncio
+import pytest
+
+from src.adapters.langchain_adapter import AlitaToolRunnable
+
+
+async def echo_tool(args: dict):
+    return args["input"]
+
+
+def test_ainvoke_validates_input_type():
+    runnable = AlitaToolRunnable(echo_tool)
+
+    with pytest.raises(TypeError):
+        asyncio.run(runnable.ainvoke("not a dict"))
+
+    result = asyncio.run(runnable.ainvoke({"input": "hello"}))
+    assert result == "hello"


### PR DESCRIPTION
## Summary
- enforce dict input for `AlitaToolRunnable`
- document adapter input format and add regression test

## What changed / Why
- added `TypeError` guard and docstring in `src/adapters/langchain_adapter.py`
- introduced unit test verifying type validation

## Risks
- minimal: new adapter module not yet wired into runtime

## Test coverage
- `tests/runtime/test_langchain_adapter.py`

## Verification
- `pre-commit run --all-files` *(fails: extension-compile-check modified files, no-debug-statements hook)*
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/runtime/test_langchain_adapter.py`

## Runtime impact
- none; adapter validates inputs before delegating

## Observability
- no telemetry changes

## Rollback
- revert this commit

------
https://chatgpt.com/codex/tasks/task_e_68ae63b1270c83289584c74a142a51bb