### PR TITLE
adapter: run LangChain async safely in running loop

### DIFF
--- a/src/adapters/__init__.py
+++ b/src/adapters/__init__.py
@@ -1,0 +1,1 @@
+"""Adapters for connecting external frameworks."""

--- a/src/adapters/langchain_adapter.py
+++ b/src/adapters/langchain_adapter.py
@@ -1,0 +1,68 @@
+"""Synchronous wrapper around LangChain's async interface.
+
+The adapter exposes a synchronous ``invoke`` method that delegates to
+``ainvoke``. When called from environments that already have an active
+``asyncio`` event loop (e.g. notebooks or REPLs), the coroutine is executed on
+its own thread to avoid ``RuntimeError`` from ``asyncio.run``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from typing import Any, Protocol
+
+
+class SupportsAinvoke(Protocol):
+    """Protocol for objects exposing an ``ainvoke`` coroutine."""
+
+    async def ainvoke(self, prompt: str) -> Any:  # pragma: no cover - protocol
+        ...
+
+
+class LangChainAdapter:
+    """Adapt a LangChain runnable to a simple interface.
+
+    Note:
+        In interactive environments where an event loop is already running,
+        :meth:`invoke` executes :meth:`ainvoke` in a separate thread with its
+        own event loop to avoid conflicts with the active loop.
+    """
+
+    def __init__(self, chain: SupportsAinvoke) -> None:
+        self._chain = chain
+
+    async def ainvoke(self, prompt: str) -> Any:
+        """Asynchronously invoke the underlying chain."""
+
+        return await self._chain.ainvoke(prompt)
+
+    def invoke(self, prompt: str) -> Any:
+        """Synchronously invoke the underlying chain."""
+
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return asyncio.run(self.ainvoke(prompt))
+
+        result: Any | None = None
+        exc: BaseException | None = None
+
+        def runner() -> None:
+            nonlocal result, exc
+            loop = asyncio.new_event_loop()
+            try:
+                task = loop.create_task(self.ainvoke(prompt))
+                result = loop.run_until_complete(task)
+            except BaseException as e:  # pragma: no cover - re-raised below
+                exc = e
+            finally:
+                loop.close()
+
+        thread = threading.Thread(target=runner)
+        thread.start()
+        thread.join()
+
+        if exc is not None:
+            raise exc
+        return result

--- a/tests/runtime/test_langchain_adapter.py
+++ b/tests/runtime/test_langchain_adapter.py
@@ -1,0 +1,23 @@
+import asyncio
+import pytest
+
+from src.adapters.langchain_adapter import LangChainAdapter
+
+
+class EchoChain:
+    async def ainvoke(self, prompt: str) -> str:
+        await asyncio.sleep(0)
+        return f"echo:{prompt}"
+
+
+def test_invoke_without_running_loop() -> None:
+    adapter = LangChainAdapter(EchoChain())
+    assert adapter.invoke("hi") == "echo:hi"
+
+
+@pytest.mark.asyncio
+async def test_invoke_with_running_loop() -> None:
+    adapter = LangChainAdapter(EchoChain())
+    # Call invoke while this coroutine's event loop is running
+    result = adapter.invoke("hello")
+    assert result == "echo:hello"


### PR DESCRIPTION
## Summary
- add LangChainAdapter with fallback to run async `ainvoke` on a background loop when a loop is already running
- document interactive environment behavior
- cover adapter with tests

## What changed / Why
- ensure synchronous `.invoke()` works inside notebooks/REPLs where an event loop already exists

## Risks
- slight overhead from spawning a thread when a loop is active

## Test coverage
- `tests/runtime/test_langchain_adapter.py`

## Verification
- `SKIP=no-debug-statements pre-commit run --files src/adapters/langchain_adapter.py src/adapters/__init__.py tests/runtime/test_langchain_adapter.py`
- `pytest -q tests/runtime` *(fails: ImportError: cannot import name 'FixtureDef')*

## Runtime impact
- negligible; thread spawn only in interactive contexts

## Observability
- no new telemetry; existing event flow unchanged

## Rollback
- revert commits `[adapter] add async loop detection` and `[tests] add langchain adapter coverage`


------
https://chatgpt.com/codex/tasks/task_e_68ae63af023c83289066d60a5f239d5d