### PR TITLE
[runtime] add event bus stress test

### DIFF
--- a/tests/runtime/test_event_bus.py
+++ b/tests/runtime/test_event_bus.py
@@ -45,3 +45,52 @@ async def test_redis_event_bus_publishes():
     assert message is not None
     data = json.loads(message["data"])
     assert data["event_type"] == "PING"
+
+
+@pytest.mark.asyncio
+async def test_event_bus_stress_throughput_and_backpressure(monkeypatch):
+    """High-volume publish test with throughput metrics and backpressure."""
+    import asyncio
+    import fakeredis.aioredis
+    import redis.asyncio as redis
+
+    from src.core.event_bus_clean import EventBus
+    from src.core.events import BaseEvent
+
+    fake = fakeredis.aioredis.FakeRedis()
+    monkeypatch.setattr(redis, "Redis", lambda *a, **k: fake)
+
+    EventBus._instance = None
+    bus = EventBus()
+
+    max_queue = 50
+    queue: asyncio.Queue[BaseEvent] = asyncio.Queue(maxsize=max_queue)
+    dropped = 0
+
+    async def handler(evt: BaseEvent) -> None:
+        nonlocal dropped
+        try:
+            queue.put_nowait(evt)
+        except asyncio.QueueFull:
+            dropped += 1
+
+    await bus.subscribe("test_event", handler)
+    await bus.start()
+
+    total = 200
+    for _ in range(total):
+        await bus.publish(BaseEvent(event_type="test_event", source_plugin="tester"))
+
+    await asyncio.sleep(1.1)
+    await bus.publish(BaseEvent(event_type="test_event", source_plugin="tester"))
+    await asyncio.sleep(0.1)
+
+    metrics = bus.get_metrics()
+    assert metrics["recv_count"] == total + 1
+    assert metrics["eps"] > 0
+
+    processed = queue.qsize()
+    assert processed <= max_queue
+    assert processed + dropped == total + 1
+
+    await bus.shutdown()


### PR DESCRIPTION
## Summary
- add high-volume stress test for EventBus throughput metrics and backpressure handling

## What changed & Why
- ensure EventBus correctly updates `recv_count` and `eps` under load using FakeRedis
- verify bounded queues drop excess events without losing messages up to configured limit

## Risks
- none; test-only change

## Test coverage
- `tests/runtime/test_event_bus.py::test_event_bus_stress_throughput_and_backpressure`

## Verification
- `pre-commit run --files tests/runtime/test_event_bus.py`
- `pytest -q tests/runtime/test_event_bus.py` *(fails: ImportError: cannot import name 'FixtureDef' from 'pytest')*

## Runtime impact
- no runtime impact; adds regression coverage

## Observability
- exercises EventBus metrics (`recv_count`, `eps`) and backpressure counters

## Rollback
- revert commit `[runtime] add event bus stress test`


------
https://chatgpt.com/codex/tasks/task_e_68ae8467f0fc8328a24493839d60ee12