### PR TITLE
[mcp] Report plugin runtime status

### DIFF
--- a/src/super_alita_mcp/capabilities_tool.py
+++ b/src/super_alita_mcp/capabilities_tool.py
@@ -45,36 +45,76 @@ def _collect_plugin_capabilities() -> list[dict[str, Any]]:
     Returns:
         List of plugin capability descriptors
     """
-    plugins = []
+    plugins: list[dict[str, Any]] = []
 
     try:
-        # Try to get plugin info from loader if available
         from ..core.plugin_loader import get_plugin_info, load_plugin_manifest
 
         manifest = load_plugin_manifest()
+        plugin_info: dict[str, Any] = {}
         if manifest:
             plugin_info = get_plugin_info(manifest)
 
-            for name, info in plugin_info.items():
-                plugins.append(
-                    {
-                        "name": name,
-                        "module": info["module"],
-                        "enabled": info["enabled"],
-                        "priority": info["priority"],
-                        "depends_on": info["depends_on"],
-                        "description": info["description"],
-                        "category": info.get("category", "uncategorized"),
-                        "status": "configured",
-                    }
-                )
+        runtime_plugins: dict[str, Any] = {}
+        try:
+            import sys
 
-        # TODO: Add runtime plugin state detection
-        # Could check if plugin instances are actually loaded and active
+            for module in list(sys.modules.values()):
+                if hasattr(module, "plugin_registry") and hasattr(
+                    getattr(module, "plugin_registry"), "plugins"
+                ):
+                    runtime_plugins = getattr(module.plugin_registry, "plugins")
+                    break
+                if hasattr(module, "plugins") and isinstance(module.plugins, dict):
+                    runtime_plugins = module.plugins
+                    break
+        except Exception as e:  # pragma: no cover - best effort
+            logger.debug(f"Runtime plugin registry inspection failed: {e}")
+
+        processed: set[str] = set()
+        for name, info in plugin_info.items():
+            instance = runtime_plugins.get(name)
+            loaded = instance is not None
+            running = bool(getattr(instance, "is_running", False)) if loaded else False
+            status = "running" if running else ("loaded" if loaded else "configured")
+
+            plugins.append(
+                {
+                    "name": name,
+                    "module": info["module"],
+                    "enabled": info["enabled"],
+                    "priority": info["priority"],
+                    "depends_on": info["depends_on"],
+                    "description": info["description"],
+                    "category": info.get("category", "uncategorized"),
+                    "status": status,
+                    "loaded": loaded,
+                    "running": running,
+                }
+            )
+            processed.add(name)
+
+        for name, instance in runtime_plugins.items():
+            if name in processed:
+                continue
+            running = bool(getattr(instance, "is_running", False))
+            plugins.append(
+                {
+                    "name": name,
+                    "module": f"{instance.__class__.__module__}:{instance.__class__.__name__}",
+                    "enabled": True,
+                    "priority": None,
+                    "depends_on": [],
+                    "description": getattr(instance, "description", ""),
+                    "category": "runtime",
+                    "status": "running" if running else "loaded",
+                    "loaded": True,
+                    "running": running,
+                }
+            )
 
     except ImportError:
         logger.debug("Plugin loader not available - using fallback detection")
-        # Fallback: try to detect from common plugin locations
         plugins.append(
             {
                 "name": "fallback_detection",

--- a/tests/runtime/test_capabilities_plugin_status.py
+++ b/tests/runtime/test_capabilities_plugin_status.py
@@ -1,0 +1,86 @@
+"""Tests for plugin capability collection runtime status."""
+
+from __future__ import annotations
+
+from types import ModuleType
+from typing import Any
+
+import sys
+
+
+class _FakePlugin:
+    def __init__(self, name: str, running: bool) -> None:
+        self.name = name
+        self.is_running = running
+
+
+def _setup_plugin_loader(monkeypatch, manifest: list[dict[str, Any]]) -> None:
+    """Patch plugin loader helpers to return a static manifest."""
+
+    info = {p["name"]: p | {"category": "uncategorized"} for p in manifest}
+
+    import src.core.plugin_loader as loader
+
+    monkeypatch.setattr(loader, "load_plugin_manifest", lambda path=None: manifest)
+    monkeypatch.setattr(loader, "get_plugin_info", lambda m: info)
+
+
+def test_collect_plugin_capabilities_reports_runtime_state(monkeypatch):
+    """Active and inactive plugins should be reported correctly."""
+
+    manifest = [
+        {
+            "name": "active",
+            "module": "mod:Active",
+            "enabled": True,
+            "priority": 1,
+            "depends_on": [],
+            "description": "Active plugin",
+        },
+        {
+            "name": "configured_only",
+            "module": "mod:Configured",
+            "enabled": True,
+            "priority": 2,
+            "depends_on": [],
+            "description": "Configured plugin",
+        },
+        {
+            "name": "loaded_only",
+            "module": "mod:Loaded",
+            "enabled": True,
+            "priority": 3,
+            "depends_on": [],
+            "description": "Loaded but not running",
+        },
+    ]
+
+    _setup_plugin_loader(monkeypatch, manifest)
+
+    runtime_module = ModuleType("runtime_orchestrator")
+    runtime_module.plugins = {
+        "active": _FakePlugin("active", True),
+        "loaded_only": _FakePlugin("loaded_only", False),
+    }
+    sys.modules["runtime_orchestrator"] = runtime_module
+
+    from src.super_alita_mcp.capabilities_tool import _collect_plugin_capabilities
+
+    try:
+        result = _collect_plugin_capabilities()
+    finally:
+        del sys.modules["runtime_orchestrator"]
+
+    by_name = {p["name"]: p for p in result}
+
+    assert by_name["active"]["loaded"] is True
+    assert by_name["active"]["running"] is True
+    assert by_name["active"]["status"] == "running"
+
+    assert by_name["configured_only"]["loaded"] is False
+    assert by_name["configured_only"]["running"] is False
+    assert by_name["configured_only"]["status"] == "configured"
+
+    assert by_name["loaded_only"]["loaded"] is True
+    assert by_name["loaded_only"]["running"] is False
+    assert by_name["loaded_only"]["status"] == "loaded"


### PR DESCRIPTION
## Summary
- track plugin loader registry to report if plugins are loaded and running
- cover plugin active/inactive cases with runtime tests

## Testing
- `pre-commit run --files src/super_alita_mcp/capabilities_tool.py tests/runtime/test_capabilities_plugin_status.py` *(fails: no-debug-statements hook)*
- `pytest -q tests/runtime` *(fails: ImportError: cannot import name 'FixtureDef' from 'pytest')*

------
https://chatgpt.com/codex/tasks/task_e_68ae8465fe1083289d7d8ebf95083b9e