### PR TITLE
core: resolve lint in runtime buses

### DIFF
--- a/src/core/error_recovery.py
+++ b/src/core/error_recovery.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
 """
-Error Recovery & Resilience System
-Implements comprehensive error recovery mechanisms with circuit breakers, retry policies,
-graceful degradation, and automatic failover strategies for the Super Alita Agent System.
+Error Recovery & Resilience System.
+
+Implements comprehensive error recovery mechanisms with circuit breakers,
+retry policies, graceful degradation, and automatic failover strategies for
+the Super Alita Agent System.
 """
 
 import asyncio
@@ -263,7 +265,10 @@ class CircuitBreaker:
         self.half_open_calls = 0
 
         self.logger.info(
-            f"Circuit breaker {self.name} transitioned: {old_state.value} -> {self.state.value}"
+            "Circuit breaker %s transitioned: %s -> %s",
+            self.name,
+            old_state.value,
+            self.state.value,
         )
         await self._emit_state_change_event(old_state)
 
@@ -276,7 +281,10 @@ class CircuitBreaker:
         self.half_open_calls = 0
 
         self.logger.warning(
-            f"Circuit breaker {self.name} transitioned: {old_state.value} -> {self.state.value}"
+            "Circuit breaker %s transitioned: %s -> %s",
+            self.name,
+            old_state.value,
+            self.state.value,
         )
         await self._emit_state_change_event(old_state)
 
@@ -288,7 +296,10 @@ class CircuitBreaker:
         self.half_open_calls = 0
 
         self.logger.info(
-            f"Circuit breaker {self.name} transitioned: {old_state.value} -> {self.state.value}"
+            "Circuit breaker %s transitioned: %s -> %s",
+            self.name,
+            old_state.value,
+            self.state.value,
         )
         await self._emit_state_change_event(old_state)
 
@@ -513,13 +524,18 @@ class ErrorRecoveryOrchestrator:
                     "operator_alert",
                     alert_level="high",
                     error_context=error_context.to_dict(),
-                    message=f"Critical error in {error_context.component_name}: {error_context.error_message}",
+                    message=(
+                        f"Critical error in {error_context.component_name}: "
+                        f"{error_context.error_message}"
+                    ),
                     source_plugin="error_recovery",
                 )
                 await self.event_bus.emit(event)
 
                 self.logger.critical(
-                    f"OPERATOR ALERT: {error_context.component_name} - {error_context.error_message}"
+                    "OPERATOR ALERT: %s - %s",
+                    error_context.component_name,
+                    error_context.error_message,
                 )
                 return True
 
@@ -557,7 +573,8 @@ class ErrorRecoveryOrchestrator:
 
         if len(recent_errors) > 10:  # More than 10 errors in 5 minutes
             self.logger.warning(
-                f"High error rate detected: {len(recent_errors)} errors in last 5 minutes"
+                "High error rate detected: %s errors in last 5 minutes",
+                len(recent_errors),
             )
 
     async def _cleanup_error_history(self) -> None:

--- a/src/core/event_bus.py
+++ b/src/core/event_bus.py
@@ -92,9 +92,9 @@ class EventBus:
             self._registered
         )  # Alias for compatibility
 
-        self._redis_subscribed: dict[str, bool] = (
-            {}
-        )  # Track Redis channel subscriptions
+        self._redis_subscribed: dict[
+            str, bool
+        ] = {}  # Track Redis channel subscriptions
         self._pubsub = None  # Redis pubsub object
 
         # Metrics tracking
@@ -222,7 +222,9 @@ class EventBus:
             logger.info("EventBus successfully connected to Memurai.")
         except Exception as e:
             logger.critical(
-                f"Could not connect to Memurai at {self.redis_url}. Is Memurai running? Error: {e}"
+                "Could not connect to Memurai at %s. Is Memurai running? Error: %s",
+                self.redis_url,
+                e,
             )
             raise
 
@@ -272,7 +274,8 @@ class EventBus:
                 self._pubsub = self._redis.pubsub()
                 self.logger.info("📡 Redis pubsub initialized")
 
-            # Optional: subscribe to a system heartbeat channel immediately to avoid "no channels" window
+            # Optional: subscribe to a system heartbeat channel immediately to
+            # avoid the initial "no channels" window
             if not self._redis_subscribed.get("__heartbeat__", False):
                 await self._pubsub.subscribe("__heartbeat__")
                 self._redis_subscribed["__heartbeat__"] = True
@@ -289,7 +292,7 @@ class EventBus:
             raise
 
     async def publish(self, event: BaseEvent) -> None:
-        """Serializes and publishes a Pydantic event to the corresponding Redis channel."""
+        """Serialize and publish a Pydantic event to its Redis channel."""
         # In-memory fallback delegation
         if hasattr(self, "_inmem") and self._inmem is not None:
             await self._inmem.publish(event)  # type: ignore[attr-defined]
@@ -393,7 +396,9 @@ class EventBus:
         handler_key = (event_type, callback.__name__)
         if handler_key in self._registered_handlers:
             logger.info(
-                f"Skipping duplicate handler '{callback.__name__}' for event type '{event_type}'."
+                "Skipping duplicate handler '%s' for event type '%s'.",
+                callback.__name__,
+                event_type,
             )
             return
         self._registered_handlers.add(handler_key)
@@ -403,7 +408,9 @@ class EventBus:
             self._handlers[event_type] = []
         self._handlers[event_type].append(callback)
         logger.info(
-            f"Handler '{callback.__name__}' registered for event type '{event_type}'."
+            "Handler '%s' registered for event type '%s'.",
+            callback.__name__,
+            event_type,
         )
 
         # CRITICAL FIX: Always subscribe to Memurai channel when handler is added
@@ -428,7 +435,7 @@ class EventBus:
                         await self._pubsub.psubscribe("*")
                         self._redis_subscribed["*"] = True  # Track pattern subscription
                         logger.info(
-                            "✅ Successfully pattern subscribed to Memurai: * (all channels)"
+                            "✅ Pattern subscribed to Memurai: * (all channels)"
                         )
                     else:
                         self._redis_subscribed["*"] = True  # Ensure tracking
@@ -446,7 +453,8 @@ class EventBus:
                         await self._pubsub.subscribe(event_type)
                         self._redis_subscribed[event_type] = True  # Track subscription
                         logger.info(
-                            f"✅ Successfully subscribed to Memurai channel: {event_type}"
+                            "✅ Subscribed to Memurai channel: %s",
+                            event_type,
                         )
                     else:
                         self._redis_subscribed[event_type] = (

--- a/src/core/event_bus_clean.py
+++ b/src/core/event_bus_clean.py
@@ -70,6 +70,9 @@ class EventBus:
         if cls._instance is None:
             cls._instance = super().__new__(cls)
             cls._instance._initialized = False
+            cls._instance._redis_host = host
+            cls._instance._redis_port = port
+            cls._instance._wire_format = wire_format
         return cls._instance
 
     def __init__(
@@ -104,7 +107,9 @@ class EventBus:
         }
 
         logger.info(
-            f"EventBus configured for Memurai at {host}:{port} with throughput optimization"
+            "EventBus configured for Memurai at %s:%s with throughput optimization",
+            host,
+            port,
         )
 
     @property
@@ -163,7 +168,10 @@ class EventBus:
             logger.info("EventBus successfully connected to Memurai.")
         except Exception as e:
             logger.critical(
-                f"Could not connect to Memurai at {self._redis_host}:{self._redis_port}. Is Memurai running? Error: {e}"
+                "Could not connect to Memurai at %s:%s. Is Memurai running? Error: %s",
+                self._redis_host,
+                self._redis_port,
+                e,
             )
             raise
 
@@ -179,15 +187,16 @@ class EventBus:
         if self._redis is not None:
             self._pubsub = self._redis.pubsub(ignore_subscribe_messages=True)
 
-        # CRITICAL FIX: Subscribe to all registered channels BEFORE starting listener
-        # This prevents the race condition where events are published before subscription
+        # CRITICAL FIX: Subscribe to all registered channels BEFORE starting the
+        # listener. This prevents events from publishing before subscriptions
         if self._subscribers and self._pubsub is not None:
             channels_to_subscribe = list(self._subscribers.keys())
 
             # Handle wildcard subscription using pattern subscription for robust support
             if "*" in channels_to_subscribe:
                 channels_to_subscribe.remove("*")
-                # Use psubscribe for true wildcard support - receives ALL published events
+                # Use psubscribe for true wildcard support. This receives all
+                # published events
                 try:
                     await self._pubsub.psubscribe("*")
                     logger.info(
@@ -202,10 +211,14 @@ class EventBus:
                 try:
                     await self._pubsub.subscribe(*channels_to_subscribe)
                     logger.info(
-                        f"✅ Pre-subscribed to Memurai channels: {channels_to_subscribe}"
+                        "✅ Pre-subscribed to Memurai channels: %s",
+                        channels_to_subscribe,
                     )
                 except Exception as e:
-                    logger.exception(f"❌ Failed to pre-subscribe to channels: {e}")
+                    logger.exception(
+                        "❌ Failed to pre-subscribe to channels: %s",
+                        e,
+                    )
                     raise
 
         # Start listener task
@@ -217,7 +230,7 @@ class EventBus:
         await asyncio.sleep(0.1)
 
     async def publish(self, event: BaseEvent) -> None:
-        """Serializes and publishes a Pydantic event to the corresponding Redis channel."""
+        """Serialize and publish a Pydantic event to its Redis channel."""
         if not self._redis:
             await self.connect()
 
@@ -228,10 +241,12 @@ class EventBus:
             if self._redis is not None:
                 await self._redis.publish(channel, serialized_data)
             logger.debug(
-                f"Published event of type '{channel}' to Memurai (wire_format: {self._wire_format})."
+                "Published event of type '%s' to Memurai (wire_format: %s).",
+                channel,
+                self._wire_format,
             )
         except Exception as e:
-            logger.exception(f"Failed to serialize/publish event: {e}")
+            logger.exception("Failed to serialize/publish event: %s", e)
             raise
 
     async def subscribe(
@@ -251,7 +266,9 @@ class EventBus:
         handler_key = (event_type, callback.__name__)
         if handler_key in self._registered_handlers:
             logger.info(
-                f"Skipping duplicate handler '{callback.__name__}' for event type '{event_type}'."
+                "Skipping duplicate handler '%s' for event type '%s'.",
+                callback.__name__,
+                event_type,
             )
             return
         self._registered_handlers.add(handler_key)
@@ -261,7 +278,9 @@ class EventBus:
             self._subscribers[event_type] = []
         self._subscribers[event_type].append(callback)
         logger.info(
-            f"Handler '{callback.__name__}' registered for event type '{event_type}'."
+            "Handler '%s' registered for event type '%s'.",
+            callback.__name__,
+            event_type,
         )
 
         # CRITICAL FIX: Always subscribe to Memurai channel when handler is added
@@ -285,7 +304,7 @@ class EventBus:
                     if "*" not in current_patterns:
                         await self._pubsub.psubscribe("*")
                         logger.info(
-                            "✅ Successfully pattern subscribed to Memurai: * (all channels)"
+                            "✅ Pattern subscribed to Memurai: * (all channels)"
                         )
                     else:
                         logger.debug("Already pattern subscribed to: *")
@@ -301,12 +320,13 @@ class EventBus:
                     if event_type not in current_channels:
                         await self._pubsub.subscribe(event_type)
                         logger.info(
-                            f"✅ Successfully subscribed to Memurai channel: {event_type}"
+                            "✅ Subscribed to Memurai channel: %s",
+                            event_type,
                         )
                     else:
-                        logger.debug(f"Already subscribed to channel: {event_type}")
+                        logger.debug("Already subscribed to channel: %s", event_type)
             except Exception as e:
-                logger.exception(f"❌ Failed to subscribe to '{event_type}': {e}")
+                logger.exception("❌ Failed to subscribe to '%s': %s", event_type, e)
                 raise  # Re-raise to ensure caller knows subscription failed
 
     async def _subscribe_to_new_channel(self, channel: str) -> None:
@@ -314,10 +334,12 @@ class EventBus:
         try:
             if self._pubsub is not None:
                 await self._pubsub.subscribe(channel)
-                logger.info(f"Dynamically subscribed to new channel: {channel}")
+                logger.info("Dynamically subscribed to new channel: %s", channel)
         except Exception as e:
             logger.exception(
-                f"Failed to dynamically subscribe to channel '{channel}': {e}"
+                "Failed to dynamically subscribe to channel '%s': %s",
+                channel,
+                e,
             )
 
     async def _listener_loop(self) -> None:
@@ -349,7 +371,11 @@ class EventBus:
                     channel = message["channel"].decode("utf-8")
                     # For pmessage, we could also access pattern with message['pattern']
 
-                logger.debug(f"📨 Received {message['type']} on channel '{channel}'")
+                logger.debug(
+                    "📨 Received %s on channel '%s'",
+                    message["type"],
+                    channel,
+                )
 
                 # Collect all handlers that should receive this event
                 handlers_to_dispatch: list[
@@ -357,29 +383,32 @@ class EventBus:
                 ] = []
 
                 # ANTI-DUPLICATE STRATEGY:
-                # If we have wildcard subscribers, prioritize pmessage and ignore regular messages
-                # This prevents the same event from being processed twice
+                # If we have wildcard subscribers, prioritize pmessage and
+                # ignore regular messages. This prevents the same event from
+                # being processed twice
                 has_wildcard_subscribers = "*" in self._subscribers
 
                 if message["type"] == "pmessage":
                     # Pattern message - dispatch to wildcard handlers
                     if has_wildcard_subscribers:
                         handlers_to_dispatch.extend(self._subscribers["*"])
-                    # Also add specific handlers for this channel (they should get the event)
+                    # Also add specific handlers for this channel (they should
+                    # get the event)
                     if channel in self._subscribers:
                         for specific_handler in self._subscribers[channel]:
                             if specific_handler not in handlers_to_dispatch:
                                 handlers_to_dispatch.append(specific_handler)
 
                 elif message["type"] == "message":
-                    # Regular message - only process if we DON'T have wildcard subscribers
-                    # (because wildcard subscribers already got this via pmessage)
+                    # Regular message - only process if we DON'T have wildcard
+                    # subscribers (wildcard subscribers already saw pmessage)
                     if not has_wildcard_subscribers:
                         # No wildcard subscribers, so process specific handlers normally
                         if channel in self._subscribers:
                             handlers_to_dispatch.extend(self._subscribers[channel])
                     else:
-                        # Has wildcard subscribers, process both specific and wildcard handlers
+                        # Has wildcard subscribers, process both specific and
+                        # wildcard handlers
                         if channel in self._subscribers:
                             handlers_to_dispatch.extend(self._subscribers[channel])
 
@@ -395,7 +424,9 @@ class EventBus:
                     )
 
                     logger.debug(
-                        f"🚀 Dispatching {event_type} to {len(handlers_to_dispatch)} handlers"
+                        "🚀 Dispatching %s to %s handlers",
+                        event_type,
+                        len(handlers_to_dispatch),
                     )
 
                     # Dispatch to all handlers asynchronously
@@ -405,13 +436,14 @@ class EventBus:
                         task.add_done_callback(background_tasks.discard)
 
             except Exception as e:
-                logger.error(f"❌ Error in event listener loop: {e}")
+                logger.error("❌ Error in event listener loop: %s", e)
                 await asyncio.sleep(1.0)  # Brief pause before retrying
 
         # Wait for any remaining background tasks to complete
         if background_tasks:
             logger.info(
-                f"⏳ Waiting for {len(background_tasks)} background tasks to complete..."
+                "⏳ Waiting for %s background tasks to complete...",
+                len(background_tasks),
             )
             await asyncio.gather(*background_tasks, return_exceptions=True)
 

--- a/src/core/mangle/grpc_server.py
+++ b/src/core/mangle/grpc_server.py
@@ -1,11 +1,12 @@
 """
-Super Alita gRPC Server
+Super Alita gRPC Server.
 
 Provides gRPC interface for external communication with the Super Alita agent system.
 Includes endpoints for Cortex operations, telemetry, knowledge graph, and optimization.
 """
 
 import asyncio
+import contextlib
 import json
 import os
 import subprocess
@@ -57,7 +58,7 @@ class SuperAlitaAgentServicer(pb2_grpc.SuperAlitaAgentServicer):
     # Health and Status Methods
 
     def GetHealth(
-        self, request: empty_pb2.Empty, context: grpc.ServicerContext
+        self, _request: empty_pb2.Empty, context: grpc.ServicerContext
     ) -> pb2.HealthResponse:
         """Get health status of the agent system."""
         try:
@@ -107,7 +108,7 @@ class SuperAlitaAgentServicer(pb2_grpc.SuperAlitaAgentServicer):
             return pb2.HealthResponse(status=pb2.HealthResponse.UNHEALTHY)
 
     def GetStatus(
-        self, request: empty_pb2.Empty, context: grpc.ServicerContext
+        self, _request: empty_pb2.Empty, context: grpc.ServicerContext
     ) -> pb2.StatusResponse:
         """Get detailed status information."""
         try:
@@ -198,7 +199,7 @@ class SuperAlitaAgentServicer(pb2_grpc.SuperAlitaAgentServicer):
             )
 
     def GetCortexStatus(
-        self, request: empty_pb2.Empty, context: grpc.ServicerContext
+        self, _request: empty_pb2.Empty, context: grpc.ServicerContext
     ) -> pb2.CortexStatusResponse:
         """Get Cortex system status."""
         try:
@@ -236,7 +237,7 @@ class SuperAlitaAgentServicer(pb2_grpc.SuperAlitaAgentServicer):
     # Telemetry Methods
 
     def GetMetrics(
-        self, request: empty_pb2.Empty, context: grpc.ServicerContext
+        self, _request: empty_pb2.Empty, context: grpc.ServicerContext
     ) -> pb2.MetricsResponse:
         """Get Prometheus-style metrics."""
         try:
@@ -333,7 +334,7 @@ class SuperAlitaAgentServicer(pb2_grpc.SuperAlitaAgentServicer):
             return pb2.CreateRelationshipResponse(success=False, error_message=str(e))
 
     def GetKnowledgeGraphStats(
-        self, request: empty_pb2.Empty, context: grpc.ServicerContext
+        self, _request: empty_pb2.Empty, context: grpc.ServicerContext
     ) -> pb2.KnowledgeGraphStatsResponse:
         """Get knowledge graph statistics."""
         try:
@@ -446,7 +447,7 @@ class SuperAlitaAgentServicer(pb2_grpc.SuperAlitaAgentServicer):
             return pb2.FeedbackResponse(success=False, error_message=str(e))
 
     def GetOptimizationStats(
-        self, request: empty_pb2.Empty, context: grpc.ServicerContext
+        self, _request: empty_pb2.Empty, context: grpc.ServicerContext
     ) -> pb2.OptimizationStatsResponse:
         """Get optimization statistics."""
         try:
@@ -503,8 +504,6 @@ class SuperAlitaAgentServicer(pb2_grpc.SuperAlitaAgentServicer):
             context.set_details(f"Optimization stats failed: {str(e)}")
             return pb2.OptimizationStatsResponse()
 
-
-
     # Mangle Query Execution (optional capability)
     def MangleQuery(
         self, request: pb2.MangleProgramRequest, context: grpc.ServicerContext
@@ -522,14 +521,23 @@ class SuperAlitaAgentServicer(pb2_grpc.SuperAlitaAgentServicer):
                     success=False, error_message="Empty program"
                 )
 
-            with tempfile.NamedTemporaryFile(mode="w", suffix=".mgl", delete=False) as f:
-                f.write(program)
-                f.flush()
-                path = f.name
+            with tempfile.NamedTemporaryFile(
+                mode="w", suffix=".mgl", delete=False
+            ) as temp_file:
+                temp_file.write(program)
+                temp_file.flush()
+                path = temp_file.name
 
             try:
+                command = [
+                    os.environ.get("MANGLE_BIN_PATH", "mangle"),
+                    "query",
+                    "--format",
+                    "json",
+                    path,
+                ]
                 proc = subprocess.run(
-                    [os.environ.get("MANGLE_BIN_PATH", "mangle"), "query", "--format", "json", path],
+                    command,
                     shell=False,
                     check=False,
                     capture_output=True,
@@ -539,32 +547,38 @@ class SuperAlitaAgentServicer(pb2_grpc.SuperAlitaAgentServicer):
                 if proc.returncode != 0:
                     return pb2.MangleProgramResponse(  # type: ignore[attr-defined]
                         success=False,
-                        error_message=f"mangle exited {proc.returncode}: {proc.stderr.strip()}",
+                        error_message=(
+                            f"mangle exited {proc.returncode}: "
+                            f"{proc.stderr.strip()}"
+                        ),
                         json_results="[]",
                         count=0,
                     )
                 out = proc.stdout.strip() or "[]"
                 try:
                     import json as _json
+
                     parsed = _json.loads(out)
                     count = len(parsed) if isinstance(parsed, list) else 0
                 except Exception:
                     parsed = []
                     count = 0
                 return pb2.MangleProgramResponse(  # type: ignore[attr-defined]
-                    success=True, json_results=json.dumps(parsed), count=count, execution_time=0.0
+                    success=True,
+                    json_results=json.dumps(parsed),
+                    count=count,
+                    execution_time=0.0,
                 )
             finally:
-                try:
+                with contextlib.suppress(Exception):
                     os.unlink(path)
-                except Exception:
-                    pass
         except Exception as e:  # pragma: no cover
             context.set_code(grpc.StatusCode.INTERNAL)
             context.set_details(f"MangleQuery failed: {e}")
             return pb2.MangleProgramResponse(  # type: ignore[attr-defined]
                 success=False, error_message=str(e), json_results="[]", count=0
             )
+
 
 class SuperAlitaGrpcServer:
     """

--- a/src/core/mangle/redis_event_bus.py
+++ b/src/core/mangle/redis_event_bus.py
@@ -240,19 +240,18 @@ class RedisEventBus:
             event_type: Type of events to unsubscribe from
             handler: Handler function to remove
         """
-        if event_type in self._subscribers:
-            if handler in self._subscribers[event_type]:
-                self._subscribers[event_type].remove(handler)
+        if event_type in self._subscribers and handler in self._subscribers[event_type]:
+            self._subscribers[event_type].remove(handler)
 
-                # Remove empty subscriber lists
-                if not self._subscribers[event_type]:
-                    del self._subscribers[event_type]
+            # Remove empty subscriber lists
+            if not self._subscribers[event_type]:
+                del self._subscribers[event_type]
 
-                    # Unsubscribe from Redis channel if no more handlers
-                    if self._pubsub:
-                        channel = self._get_channel_name(event_type)
-                        await self._pubsub.unsubscribe(channel)
-                        logger.info(f"Unsubscribed from events of type '{event_type}'")
+                # Unsubscribe from Redis channel if no more handlers
+                if self._pubsub:
+                    channel = self._get_channel_name(event_type)
+                    await self._pubsub.unsubscribe(channel)
+                    logger.info(f"Unsubscribed from events of type '{event_type}'")
 
     async def get_event_history(
         self, event_type: str, limit: int = 100, start_time: str | None = None


### PR DESCRIPTION
## Summary
- tighten circuit breaker logging and alert formatting in `src/core/error_recovery.py`
- normalize Memurai event bus logging, docstrings, and singleton initialization logic in `src/core/event_bus.py` and `src/core/event_bus_clean.py`
- clean up gRPC runtime surfaces by renaming unused request parameters, using `contextlib.suppress`, and shortening long subprocess/logging lines in `src/core/mangle/grpc_server.py`
- collapse redundant subscriber guards in `src/core/mangle/redis_event_bus.py`

## What changed / Why
- long log strings and docstrings triggered Ruff E501 violations; refactoring them removes width breaches without altering behavior
- unused `request` parameters and nested guards generated Ruff ARG/SIM warnings; renaming and combining checks quiet the linter while preserving interfaces
- restructuring long subprocess invocations and cleanup blocks keeps formatting under 88 characters and aligns with style guidance

## Risks
- minimal: changes are limited to logging, formatting, and guard clauses; runtime semantics remain intact

## Test coverage
- no new tests were added (lint-only refactor)

## Verification
- `SKIP=mypy pre-commit run --files src/core/error_recovery.py src/core/event_bus.py src/core/event_bus_clean.py src/core/mangle/grpc_server.py src/core/mangle/redis_event_bus.py` (pass)
- `pytest -q tests/runtime` *(fails: pytest-asyncio plugin imports `FixtureDef` which is unavailable in bundled pytest)*

## Runtime impact
- none; behavior and performance characteristics are unchanged aside from cleaner log output

## Observability
- log messages now rely on parameterized templates but expose the same information

## Rollback
- revert commit `core: resolve lint in runtime buses`


------
https://chatgpt.com/codex/tasks/task_e_68c86bbbdb508328926b78e5f1d79f13

## Summary by Sourcery

Refactor various runtime bus modules to resolve lint violations by parameterizing log messages, breaking down long lines and docstrings, normalizing event bus initialization, renaming unused parameters, using contextlib.suppress for cleanup, and simplifying subscriber guard logic.

Enhancements:
- Parameterize all log and exception messages to use %-style templates instead of f-strings
- Reformat long docstrings and log lines across event_bus, grpc_server, and error_recovery modules to comply with line-length limits
- Rename unused gRPC request parameters to _request to silence linter ARG warnings
- Use contextlib.suppress to clean up temporary files without verbose try/except blocks
- Collapse nested subscriber existence checks in redis event bus unsubscribe logic
- Initialize host, port, and wire_format attributes in the event_bus_clean singleton constructor