### PR TITLE
[reug_runtime] Harden typing for streaming router

### DIFF
--- a/src/plugins/message_amplifier_plugin.py
+++ b/src/plugins/message_amplifier_plugin.py
@@ -41,4 +41,4 @@ def amplify_message(message: str, ctx: MessageContext) -> tuple[str, dict[str, s
 
 
 # Register on import so router can just import the module when enabled.
-register(amplify_message)  # type: ignore[arg-type]
+register(amplify_message)

--- a/src/reug_runtime/__init__.py
+++ b/src/reug_runtime/__init__.py
@@ -5,10 +5,12 @@ triggering the full router import (which may fail during partial checkouts
 or conflict resolution). Routers are available via lazy attribute access.
 """
 
+from typing import Any
+
 __all__ = ["router", "tools", "TOOL_CATALOG"]
 
 
-def __getattr__(name: str):  # pragma: no cover - small helper
+def __getattr__(name: str) -> Any:  # pragma: no cover - small helper
     if name == "router":
         from .router import router as _router
 

--- a/src/reug_runtime/config.py
+++ b/src/reug_runtime/config.py
@@ -117,7 +117,7 @@ class Settings:
     tool_registry_dir: str | None = _getenv("REUG_TOOL_REGISTRY_DIR")
 
     # HTTP server
-    api_prefix: str = _getenv("API_PREFIX", "/")
+    api_prefix: str = _getenv("API_PREFIX", "/") or "/"
 
     # Generation controls
     default_temperature: float = _getenv_float("REUG_DEFAULT_TEMPERATURE", 0.2)

--- a/src/reug_runtime/router.py
+++ b/src/reug_runtime/router.py
@@ -148,8 +148,7 @@ class Orchestrator:
                             "owner": a.get("owner"),
                             "repo": a.get("repo"),
                             "path": a.get("path"),
-                            **({"ref": a.get("ref")} if a.get("ref") else {}),
-                        },
+                        } | ({"ref": a.get("ref")} if a.get("ref") else {}),
                     )
                     return cast(dict[str, Any], result)
 

--- a/src/reug_runtime/router.py
+++ b/src/reug_runtime/router.py
@@ -347,11 +347,7 @@ class Orchestrator:
                 )
             except Exception:
                 tool_args_obj = {}
-            tool_args: dict[str, Any]
-            if isinstance(tool_args_obj, dict):
-                tool_args = tool_args_obj
-            else:
-                tool_args = {}
+            tool_args: dict[str, Any] = tool_args_obj if isinstance(tool_args_obj, dict) else {}
             span_id = str(uuid.uuid4())
 
             ability_called_event = {

--- a/src/reug_runtime/router.py
+++ b/src/reug_runtime/router.py
@@ -15,6 +15,7 @@ conflicts are resolved or provider-specific logic evolves.
 """
 
 import asyncio
+import contextlib
 import json
 import os
 import re
@@ -23,15 +24,41 @@ import urllib.request
 import uuid
 from collections.abc import AsyncGenerator
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from fastapi import APIRouter, Request
-from fastapi.responses import StreamingResponse
+from fastapi.responses import JSONResponse, StreamingResponse
 
 from .config import SETTINGS
 from .message_mw import MessageContext, apply_all
 
 router = APIRouter(prefix="/v1", tags=["agent"])
+
+
+def parse_tool_calls(text: str) -> list[dict[str, Any]]:
+    """Parse serialized ``<tool_call>`` blocks from streamed text."""
+
+    calls: list[dict[str, Any]] = []
+    try:
+        for match in re.finditer(r"<tool_call>(.*?)</tool_call>", text, re.DOTALL):
+            inner = match.group(1)
+            payload = json.loads(inner)
+            name = payload.get("tool")
+            raw_args = payload.get("args", {})
+            if not isinstance(name, str) or not name:
+                continue
+            if not isinstance(raw_args, dict):
+                continue
+            call: dict[str, Any] = {
+                "id": str(uuid.uuid4()),
+                "name": name,
+                "function": {"name": name, "arguments": json.dumps(raw_args)},
+            }
+            calls.append(call)
+    except Exception:
+        # best-effort parsing only
+        pass
+    return calls
 
 
 class Orchestrator:
@@ -41,6 +68,8 @@ class Orchestrator:
         self.model = model
         self.correlation_id = correlation_id
         self._mcp_box_dir = Path(os.getenv("MCP_BOX_DIR", ".mcp_box"))
+        self._last_reasoning_result: tuple[str, list[Any]] = ("", [])
+        self._last_acting_result: list[dict[str, Any]] = []
 
     def _persist_mcp_spec(self, spec: dict[str, Any]) -> None:
         try:
@@ -113,7 +142,7 @@ class Orchestrator:
                 }
 
                 async def _exec(a: dict[str, Any]) -> dict[str, Any]:  # proxy
-                    return await self.registry.execute(  # type: ignore[return-value]
+                    result = await self.registry.execute(
                         "fetch_github_raw",
                         {
                             "owner": a.get("owner"),
@@ -122,6 +151,7 @@ class Orchestrator:
                             **({"ref": a.get("ref")} if a.get("ref") else {}),
                         },
                     )
+                    return cast(dict[str, Any], result)
 
                 self.registry.register_tool(contract=contract, executor=_exec)
                 # Persist spec for reuse
@@ -169,9 +199,7 @@ class Orchestrator:
 
                     def _do_fetch() -> dict[str, Any]:
                         try:
-                            with urllib.request.urlopen(
-                                url, timeout=8
-                            ) as resp:  # nosec B310
+                            with urllib.request.urlopen(url, timeout=8) as resp:  # nosec B310
                                 raw = resp.read()
                             text = raw.decode("utf-8", errors="replace")
                             truncated = False
@@ -242,7 +270,7 @@ class Orchestrator:
         self, messages: list[dict[str, Any]], tool_schemas: list[dict[str, Any]]
     ) -> AsyncGenerator[dict[str, Any], None]:
         llm_response_content = ""
-        tool_calls = []
+        tool_calls: list[Any] = []
 
         # Call model.stream_chat with best-effort compatibility across providers
         async def _stream() -> AsyncGenerator[dict[str, Any], None]:
@@ -250,8 +278,8 @@ class Orchestrator:
                 # Preferred: pass tools and timeout if supported
                 async for ch in self.model.stream_chat(
                     messages,
-                    tools=tool_schemas,  # type: ignore[call-arg]
-                    timeout=SETTINGS.model_stream_timeout_s,  # type: ignore[arg-type]
+                    tools=tool_schemas,
+                    timeout=SETTINGS.model_stream_timeout_s,
                 ):
                     yield ch
                 return
@@ -261,7 +289,7 @@ class Orchestrator:
                 # Fallback: pass only timeout
                 async for ch in self.model.stream_chat(
                     messages,
-                    timeout=SETTINGS.model_stream_timeout_s,  # type: ignore[arg-type]
+                    timeout=SETTINGS.model_stream_timeout_s,
                 ):
                     yield ch
                 return
@@ -282,9 +310,9 @@ class Orchestrator:
         self._last_reasoning_result = (llm_response_content, tool_calls)
 
     async def _acting_step(
-        self, tool_calls: list[dict[str, Any]]
+        self, tool_calls: list[Any]
     ) -> AsyncGenerator[dict[str, Any], None]:
-        tool_messages = []
+        tool_messages: list[dict[str, Any]] = []
         for tool_call in tool_calls:
             # Support both OpenAI SDK objects and plain dicts
             if hasattr(tool_call, "function"):
@@ -313,12 +341,17 @@ class Orchestrator:
                 continue
 
             try:
-                tool_args = (
+                tool_args_obj: Any = (
                     json.loads(tool_args_raw)
                     if isinstance(tool_args_raw, str)
                     else (tool_args_raw or {})
                 )
             except Exception:
+                tool_args_obj = {}
+            tool_args: dict[str, Any]
+            if isinstance(tool_args_obj, dict):
+                tool_args = tool_args_obj
+            else:
                 tool_args = {}
             span_id = str(uuid.uuid4())
 
@@ -330,9 +363,7 @@ class Orchestrator:
             }
             # include args for UI visibility
             try:
-                ability_called_event["args"] = json.loads(
-                    tool_args if isinstance(tool_args, str) else json.dumps(tool_args)
-                )
+                ability_called_event["args"] = json.loads(json.dumps(tool_args))
             except Exception:
                 ability_called_event["args"] = tool_args
             await self.event_bus.emit(ability_called_event)
@@ -342,9 +373,12 @@ class Orchestrator:
             await self._ensure_tool(tool_name or "", tool_args)
 
             try:
-                result = await asyncio.wait_for(
-                    self.registry.execute(tool_name, tool_args),
-                    timeout=SETTINGS.tool_timeout_s,
+                result = cast(
+                    dict[str, Any],
+                    await asyncio.wait_for(
+                        self.registry.execute(tool_name, tool_args),
+                        timeout=SETTINGS.tool_timeout_s,
+                    ),
                 )
                 ability_succeeded_event = {
                     "type": "AbilitySucceeded",
@@ -454,51 +488,22 @@ async def execute_turn(
 
     llm_response_content = ""
 
-    def _parse_tool_calls(text: str) -> list[dict[str, Any]]:
-        calls: list[dict[str, Any]] = []
-        try:
-            for m in re.finditer(r"<tool_call>(.*?)</tool_call>", text, re.DOTALL):
-                inner = m.group(1)
-                payload = json.loads(inner)
-                name = payload.get("tool")
-                args = payload.get("args", {})
-                if not name:
-                    continue
-
-                # Minimal adapter object with .function.name/.function.arguments
-                class _Fn:
-                    def __init__(self, n: str, a: str) -> None:
-                        self.name = n
-                        self.arguments = a
-
-                class _Call:
-                    def __init__(self, i: str, fn: _Fn) -> None:
-                        self.id = i
-                        self.function = fn
-
-                calls.append(
-                    _Call(
-                        i=str(uuid.uuid4()),
-                        fn=_Fn(name, json.dumps(args)),
-                    )
-                )
-        except Exception:
-            # best-effort parsing only
-            pass
-        return calls
-
     for _ in range(SETTINGS.max_tool_calls):
-        tool_schemas = registry.get_available_tools_schema()
+        tool_schemas: list[dict[str, Any]] = registry.get_available_tools_schema()
 
         # Run reasoning step and get results
         async for event in orchestrator._reasoning_step(messages, tool_schemas):
             yield event
-        llm_response_content, tool_calls = orchestrator._last_reasoning_result
+        llm_response_content, tool_calls_raw = orchestrator._last_reasoning_result
+        tool_calls: list[Any] = list(tool_calls_raw)
         # Fallback: derive tool calls by parsing streamed content blocks
         if not tool_calls and "<tool_call>" in llm_response_content:
-            tool_calls = _parse_tool_calls(llm_response_content)
+            tool_calls = parse_tool_calls(llm_response_content)
 
-        assistant_message = {"role": "assistant", "content": llm_response_content}
+        assistant_message: dict[str, Any] = {
+            "role": "assistant",
+            "content": llm_response_content,
+        }
         if tool_calls:
             assistant_message["tool_calls"] = tool_calls
         messages.append(assistant_message)
@@ -646,14 +651,14 @@ async def sse_transformer(
 
     queue: asyncio.Queue[dict[str, Any] | None] = asyncio.Queue()
 
-    async def _pump():
+    async def _pump() -> None:
         try:
             async for ev in event_generator:
                 await queue.put(ev)
         finally:
             await queue.put(None)
 
-    async def _pings():
+    async def _pings() -> None:
         if not use_hb:
             return
         try:
@@ -689,7 +694,7 @@ async def sse_transformer(
 
 
 @router.post("/chat/stream")
-async def chat_stream(request: Request):
+async def chat_stream(request: Request) -> StreamingResponse | JSONResponse:
     # Rate limit pre-check (optional)
     try:
         if os.getenv("ALITA_RATE_LIMIT_ENABLED", "false").lower() in {
@@ -724,17 +729,24 @@ async def chat_stream(request: Request):
                     )
     except Exception:
         pass
-    body = await request.json()
+    raw_body = await request.json()
+    body: dict[str, Any]
+    if isinstance(raw_body, dict):
+        body = raw_body
+    else:
+        body = {}
     user_msg = body.get("message", "")
     session_id = body.get("session_id", "default")
+
+    state = cast(Any, request.app.state)
 
     event_gen = execute_turn(
         user_msg,
         session_id,
-        request.app.state.event_bus,
-        request.app.state.ability_registry,
-        request.app.state.kg,
-        request.app.state.llm_model,
+        state.event_bus,
+        state.ability_registry,
+        state.kg,
+        state.llm_model,
     )
 
     sse_gen = sse_transformer(event_gen)
@@ -747,7 +759,7 @@ async def chat_stream(request: Request):
 
 
 @router.get("/chat/stream")
-async def chat_stream_get(request: Request):
+async def chat_stream_get(request: Request) -> StreamingResponse:
     """
     GET variant to support browsers using EventSource.
 
@@ -755,17 +767,19 @@ async def chat_stream_get(request: Request):
       - q or message
       - session or session_id
     """
-    qp = request.query_params  # type: ignore[attr-defined]
+    qp = request.query_params
     user_msg = qp.get("q") or qp.get("message") or ""
     session_id = qp.get("session") or qp.get("session_id") or "default"
+
+    state = cast(Any, request.app.state)
 
     event_gen = execute_turn(
         user_msg,
         session_id,
-        request.app.state.event_bus,
-        request.app.state.ability_registry,
-        request.app.state.kg,
-        request.app.state.llm_model,
+        state.event_bus,
+        state.ability_registry,
+        state.kg,
+        state.llm_model,
     )
 
     sse_gen = sse_transformer(event_gen)

--- a/src/reug_runtime/router_tools.py
+++ b/src/reug_runtime/router_tools.py
@@ -15,7 +15,7 @@ import json
 import os
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from fastapi import APIRouter, Body, HTTPException, Request
 from fastapi.responses import JSONResponse
@@ -260,13 +260,14 @@ async def reug_start_turn(
     """
     message = body["message"]
     session_id = body.get("session_id", "default")
+    state = cast(Any, request.app.state)
     gen = execute_turn(
         message,
         session_id,
-        event_bus=request.app.state.event_bus,
-        registry=request.app.state.ability_registry,
-        kg=request.app.state.kg,
-        model=request.app.state.llm_model,
+        event_bus=state.event_bus,
+        registry=state.ability_registry,
+        kg=state.kg,
+        model=state.llm_model,
     )
     run_id = f"run_{hash((message, session_id)) & 0xffff_ffff:x}"
     _STREAMS[run_id] = gen.__aiter__()
@@ -429,7 +430,8 @@ async def execute_tool(
     if not isinstance(args, dict):
         raise HTTPException(status_code=400, detail="args must be an object")
 
-    registry = request.app.state.ability_registry  # type: ignore[attr-defined]
+    state = cast(Any, request.app.state)
+    registry = state.ability_registry
     # Allow longer time for heavier tools (e.g., consensus)
     _timeout = SETTINGS.tool_timeout_s
     if tid == "deepconf_consensus":
@@ -476,7 +478,8 @@ async def execute_tool_path(
         args = {}
     if not isinstance(args, dict):
         raise HTTPException(status_code=400, detail="args must be an object")
-    registry = request.app.state.ability_registry  # type: ignore[attr-defined]
+    state = cast(Any, request.app.state)
+    registry = state.ability_registry
     _timeout = SETTINGS.tool_timeout_s
     if tool_id == "deepconf_consensus":
         ns = 0
@@ -636,7 +639,7 @@ async def mcp_register(
       - echo_plan: split task into 3 bullet steps
     """
     action = spec.get("action") or ""
-    box_dir = os.getenv("MCP_BOX_DIR", ".mcp_box")
+    box_dir = os.getenv("MCP_BOX_DIR", ".mcp_box") or ".mcp_box"
 
     # Check if a canonical tool already exists for this action and schema
     # First, run the abstractor to ensure index.json is up to date
@@ -675,7 +678,8 @@ async def mcp_register(
         tool_id = _persist_spec(spec)
         print(f"🔍 DEBUG: Persisted new tool spec: {tool_id}")
 
-    registry = request.app.state.ability_registry  # type: ignore[attr-defined]
+    state = cast(Any, request.app.state)
+    registry = state.ability_registry
 
     async def _exec(args: dict[str, Any]) -> dict[str, Any]:
         if action == "fetch_url_text":
@@ -698,7 +702,7 @@ async def mcp_register(
                 return {"content": "", "truncated": False, "error": str(e)}
         if action == "fetch_github_raw":
             # Delegate to the built-in dynamic executor registered in SimpleAbilityRegistry
-            return await registry.execute(
+            result = await registry.execute(
                 "fetch_github_raw",
                 {
                     "owner": args.get("owner"),
@@ -707,6 +711,7 @@ async def mcp_register(
                     **({"ref": args.get("ref")} if args.get("ref") else {}),
                 },
             )
+            return cast(dict[str, Any], result)
         if action == "echo_plan":
             task = (args.get("task") or "").strip()
             steps = [f"Understand: {task}", "Identify resources", "Execute and verify"]
@@ -742,7 +747,14 @@ async def mcp_abstract(
     Input (optional): {"mcp_box_dir": ".mcp_box"}
     Output: index summary (as written to index.json)
     """
-    box_dir = body.get("mcp_box_dir") or os.getenv("MCP_BOX_DIR", ".mcp_box")
+    raw_dir = body.get("mcp_box_dir") if isinstance(body, dict) else None
+    box_dir: str | Path
+    if raw_dir is None:
+        box_dir = os.getenv("MCP_BOX_DIR", ".mcp_box") or ".mcp_box"
+    elif isinstance(raw_dir, (str, Path)):
+        box_dir = raw_dir
+    else:
+        raise HTTPException(status_code=400, detail="mcp_box_dir must be a path")
     result = abstract_mcp_box(box_dir)
     return JSONResponse(result)
 
@@ -754,7 +766,7 @@ async def mcp_catalog() -> JSONResponse:
     Returns the lightweight catalog.json for direct tool loading.
     If catalog.json doesn't exist, automatically abstracts and generates it.
     """
-    box_dir = os.getenv("MCP_BOX_DIR", ".mcp_box")
+    box_dir = os.getenv("MCP_BOX_DIR", ".mcp_box") or ".mcp_box"
     catalog_path = Path(box_dir) / "catalog.json"
 
     if not catalog_path.exists():

--- a/tests/runtime/test_router_tool_parsing.py
+++ b/tests/runtime/test_router_tool_parsing.py
@@ -1,0 +1,28 @@
+"""Tests for helper utilities in :mod:`src.reug_runtime.router`."""
+
+import json
+
+from src.reug_runtime.router import parse_tool_calls
+
+
+def test_parse_tool_calls_generates_dict_payload() -> None:
+    text = '<tool_call>{"tool":"search","args":{"query":"plan"}}</tool_call>'
+
+    calls = parse_tool_calls(text)
+
+    assert len(calls) == 1
+    call = calls[0]
+    assert call["name"] == "search"
+    fn = call["function"]
+    assert isinstance(fn, dict)
+    assert fn["name"] == "search"
+    assert json.loads(fn["arguments"]) == {"query": "plan"}
+    assert isinstance(call["id"], str) and call["id"]
+
+
+def test_parse_tool_calls_ignores_invalid_payload() -> None:
+    text = '<tool_call>{"tool":"search","args":[]}</tool_call>'
+
+    calls = parse_tool_calls(text)
+
+    assert calls == []


### PR DESCRIPTION
## Summary
- add explicit typing for the streaming orchestrator and expose a reusable `parse_tool_calls` helper for fallback tool-call decoding
- tighten runtime helpers by replacing permissive casts, fixing optional env handling, and removing stale ignores in the amplifier plugin
- cover the new helper with a focused unit test that exercises dict-based tool-call synthesis

## What changed / Why
- prevents `Any` leakage in the REUG streaming path and avoids runtime surprises when the LLM emits inline tool calls
- reduces reliance on ignores by casting registry results and normalising FastAPI state access, keeping mypy `--strict` green
- ensures API prefix defaults cannot become `None`, matching server expectations

## Risks
- low: logic refactors are limited to typing-oriented guards and defensive casts; behaviour mirrors existing flows

## Test coverage
- new test ensures fallback parsing returns dict structures compatible with downstream handling

## Verification
- `mypy --strict @chunks/reug_runtime_router.txt` ✅
- `pre-commit run --all-files` ❌ (fails on unrelated repository lint/mypy issues)
- `pytest -q tests/runtime` ❌ (pytest_asyncio plugin incompatible with bundled pytest version)

## Runtime impact
- no change to execution flow; only added casts and helper extraction

## Observability
- no telemetry schema changes

## Rollback
- revert this commit to restore prior typing and routing helper behaviour

------
https://chatgpt.com/codex/tasks/task_e_68c86bc1b9288328bf5c5a1c0655031a

## Summary by Sourcery

Harden typing and fallback parsing in the streaming router by adding explicit types, extracting a reusable helper, and normalizing FastAPI state and environment defaults.

New Features:
- Introduce parse_tool_calls utility for best-effort decoding of <tool_call> blocks from streamed text.

Bug Fixes:
- Fix handling of optional environment variables to align with server expectations.

Enhancements:
- Tighten runtime guards by replacing permissive casts and removing stale type ignores.
- Normalize FastAPI request state access via explicit casting to avoid attribute errors.
- Annotate internal fields and functions with precise types and return annotations.
- Ensure environment defaults (API_PREFIX, MCP_BOX_DIR) cannot become None.

Tests:
- Add unit tests for parse_tool_calls covering valid and invalid payloads.