### PR TITLE
[tests] Guard asyncio plugin compatibility

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,7 +1,7 @@
 # Test requirements
 # Keep pytest aligned with the minversion specified in pyproject.toml
 pytest>=8.0.0
-pytest-asyncio>=0.21.0
+pytest-asyncio>=0.23.6
 
 # Jest-equivalent testing packages for complete Jest-like workflow
 pytest-cov>=4.0.0           # Coverage reporting (jest --coverage)

--- a/tests/runtime/test_mcp_registry_stream.py
+++ b/tests/runtime/test_mcp_registry_stream.py
@@ -1,4 +1,7 @@
 import pytest
+
+pytest.importorskip("hypothesis")
+
 from hypothesis import given
 from hypothesis import strategies as st
 


### PR DESCRIPTION
## Summary
- raise the pytest-asyncio test dependency to a version that supports pytest 8+
- guard the Hypothesis-based MCP registry tests so they skip cleanly when Hypothesis is unavailable

## What changed / Why
Pytest 8 removes the legacy `pytest.FixtureDef` alias that older pytest-asyncio releases relied on. Updating the test dependency prevents early-import crashes when running the runtime suite. The additional `pytest.importorskip("hypothesis")` call keeps the Hypothesis-driven regression tests aligned with the documented optional dependency so developers without Hypothesis still get a graceful skip instead of a hard failure.

## Risks
- Minimal: the dependency bump only affects the test environment and requires pytest-asyncio ≥0.23.6 to be installed.

## Test coverage
- Existing property-based tests continue to cover the MCP registry behaviour when Hypothesis is installed.

## Verification
- `pytest -q tests/runtime` *(fails: numerous pre-existing runtime regressions; command now runs through collection)*
- `pytest -q tests/runtime/test_mcp_registry_stream.py` *(fails: underlying registry uses asyncio.run inside running loop)*

## Runtime impact
- None; changes are limited to test dependencies and guards.

## Observability
- No changes to logging or telemetry.

## Rollback
- Revert this commit to restore the previous dependency pin and remove the import guard.


------
https://chatgpt.com/codex/tasks/task_e_68c86bc7736c8328b6d24ffa1b40f877

## Summary by Sourcery

Raise the pytest-asyncio dependency to support pytest 8+ and add a pytest.importorskip guard for Hypothesis in MCP registry tests

Enhancements:
- Bump pytest-asyncio test dependency to version 0.23.6 or higher to maintain compatibility with pytest 8+

Tests:
- Add pytest.importorskip("hypothesis") to MCP registry stream tests to gracefully skip when Hypothesis is unavailable