### PR TITLE
tools: improve chunk manifest CLI and docs

### DIFF
--- a/chunks/tests-runtime.txt
+++ b/chunks/tests-runtime.txt
@@ -65,11 +65,13 @@ tests/runtime/test_router_circuit_breaker.py
 tests/runtime/test_router_config_limits.py
 tests/runtime/test_router_disconnect.py
 tests/runtime/test_router_dynamic_tool.py
+tests/runtime/test_router_knowledge_graph.py
 tests/runtime/test_router_model_stream_timeout.py
 tests/runtime/test_router_result_cap.py
 tests/runtime/test_router_retry.py
 tests/runtime/test_router_schema_bypass.py
 tests/runtime/test_router_smoke.py
+tests/runtime/test_router_tool_parsing.py
 tests/runtime/test_router_tools_git_patch.py
 tests/runtime/test_router_tools_io.py
 tests/runtime/test_router_tools_pytest_run.py

--- a/tools/AGENTS.md
+++ b/tools/AGENTS.md
@@ -1058,6 +1058,7 @@ python tools/dev/env_manager.py               # Check/setup environment
 python tools/chunk_repo.py                    # Generate chunks/chunk manifests
 python tools/chunk_repo.py --dry-run          # Preview without writing files
 python tools/chunk_repo.py --output-dir tmp   # Customise manifest directory
+python tools/chunk_repo.py src tests other    # Scan only specified paths
 
 # Building and packaging
 python tools/build/builder.py --all           # Build everything
@@ -1084,9 +1085,12 @@ python tools/maintenance/cleanup.py --logs    # Clean logs only
   while respecting the scope boundaries defined by `AGENTS.md` files.
 - **Output** - Creates (or updates) text files in `chunks/` (e.g.,
   `chunks/core.txt` or `chunks/tests-runtime.txt`) listing repository-relative
-  paths.
+  paths. Precomputed manifests ship in the `chunks/` directory for immediate
+  use.
 - **Options** - Use `--dry-run` to inspect the manifests without writing them
   and `--output-dir` to target an alternate directory for the generated files.
+- **Paths** - Provide optional positional arguments to limit scanning to
+  specific directories (defaults: `src` and `tests`).
 
 
 ### Best Practices

--- a/tools/chunk_repo.py
+++ b/tools/chunk_repo.py
@@ -1,13 +1,17 @@
 """Generate chunk manifests for repository Python files.
 
 This script discovers Python modules under ``src/`` and ``tests/`` and groups
-them into chunk manifests that respect ``AGENTS.md`` scope boundaries.  Each
+them into chunk manifests that respect ``AGENTS.md`` scope boundaries. Each
 manifest lists the Python files associated with a top-level directory (for
 example ``src/core`` or ``tests/runtime``) and is written to the ``chunks``
 directory.
 
+By default the script scans the ``src`` and ``tests`` directories, but
+additional repository-relative paths may be provided as positional arguments.
+
 Usage:
-    python tools/chunk_repo.py
+    python tools/chunk_repo.py [paths...]
+    python tools/chunk_repo.py src tests integrations
 
 The output directory can be customised via ``--output-dir`` and the script can
 run in dry-run mode with ``--dry-run`` to preview the manifests without writing
@@ -18,12 +22,12 @@ from __future__ import annotations
 
 import argparse
 from collections import defaultdict
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable, Mapping
-
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_PATHS = ("src", "tests")
 
 
 @dataclass(frozen=True)
@@ -83,14 +87,15 @@ def chunk_key_for(file_path: Path, agent_dirs: set[Path]) -> tuple[str, ...]:
             # Scope aligns with a top-level directory (e.g. ``src/core``)
             if (scope_parts[0], scope_parts[1]) != (root, top_level):
                 msg = (
-                    "AGENTS.md scope mismatch: file %s is in %s but governed by %s"
-                    % (relative.as_posix(), f"{root}/{top_level}", "/".join(scope_parts))
+                    "AGENTS.md scope mismatch: file"
+                    f" {relative.as_posix()} is in {root}/{top_level}"
+                    f" but governed by {'/'.join(scope_parts)}"
                 )
                 raise ValueError(msg)
         elif scope_parts and scope_parts[0] != root:
             msg = (
-                "AGENTS.md scope for file %s does not align with root directory"
-                % relative.as_posix()
+                "AGENTS.md scope for file"
+                f" {relative.as_posix()} does not align with root directory"
             )
             raise ValueError(msg)
 
@@ -112,11 +117,13 @@ def render_chunk_name(chunk_key: tuple[str, ...]) -> str:
     return "-".join(chunk_key)
 
 
-def build_chunks(agent_dirs: set[Path]) -> Mapping[tuple[str, ...], list[Path]]:
+def build_chunks(
+    agent_dirs: set[Path], base_dirs: Iterable[str]
+) -> Mapping[tuple[str, ...], list[Path]]:
     """Group repository Python files into chunk manifests."""
 
     chunked: dict[tuple[str, ...], list[Path]] = defaultdict(list)
-    for file_path in iter_python_files(["src", "tests"]):
+    for file_path in iter_python_files(base_dirs):
         chunk_key = chunk_key_for(file_path, agent_dirs)
         chunked[chunk_key].append(file_path.relative_to(REPO_ROOT))
 
@@ -159,6 +166,12 @@ def write_chunks(
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
+        "paths",
+        nargs="*",
+        default=list(DEFAULT_PATHS),
+        help="Repository-relative directories to scan for Python files",
+    )
+    parser.add_argument(
         "--output-dir",
         type=Path,
         default=REPO_ROOT / "chunks",
@@ -175,7 +188,7 @@ def parse_args() -> argparse.Namespace:
 def main() -> None:
     args = parse_args()
     agent_dirs = find_agent_directories(REPO_ROOT)
-    chunks = build_chunks(agent_dirs)
+    chunks = build_chunks(agent_dirs, args.paths)
     entries = write_chunks(chunks, args.output_dir, dry_run=args.dry_run)
 
     for entry in entries:


### PR DESCRIPTION
## Summary
- allow chunk_repo to scan custom directories
- document chunk manifest generator usage and ship updated manifests

## Testing
- `pre-commit run --files tools/chunk_repo.py tools/AGENTS.md chunks/tests-runtime.txt`
- `pytest -q tests/runtime` *(fails: ImportError: cannot import name 'FixtureDef')*

------
https://chatgpt.com/codex/tasks/task_e_68c877dfcd708328a9b1a8a5f0780415

## Summary by Sourcery

Enable configurable scan paths for Python chunk manifest generation and update related documentation

New Features:
- Allow specifying repository-relative scan directories as positional arguments in chunk_repo.py (defaulting to src and tests)

Enhancements:
- Replace hardcoded scan paths with a DEFAULT_PATHS constant and propagate args.paths to build_chunks

Documentation:
- Augment tool docstring and AGENTS.md with examples and help text for the new paths argument