### PR TITLE
scripts: add sdd slugify helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ downloads/
 eggs/
 .eggs/
 lib/
+!scripts/lib/
+!scripts/lib/**
 lib64/
 parts/
 sdist/

--- a/scripts/lib/sdd-common.sh
+++ b/scripts/lib/sdd-common.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Common helper utilities for SDD shell tooling.
+# Provides a slugify helper that mirrors the Python implementation.
+slugify() {
+    local input="${1:-}"
+    if [[ -z "${input}" ]]; then
+        printf '\n'
+        return 0
+    fi
+
+    local slug
+    slug=$(printf '%s' "${input}" \
+        | tr '[:upper:]' '[:lower:]' \
+        | sed -E 's/[^a-z0-9]+/-/g' \
+        | sed -E 's/^-+|-+$//g')
+
+    printf '%s\n' "${slug}"
+}
+
+# Basic self-test when the script is executed directly.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    expected="my-feature-123"
+    result="$(slugify "My Feature 123!")"
+
+    if [[ "${result}" != "${expected}" ]]; then
+        echo "slugify self-test failed: expected '${expected}', got '${result}'" >&2
+        exit 1
+    fi
+
+    echo "slugify self-test passed"
+fi


### PR DESCRIPTION
## Summary
- add a shared `slugify` helper for SDD shell tooling with extended regular expression support
- wire a simple self-test that covers the `slugify "My Feature 123!"` happy path
- unignore `scripts/lib/` so shared shell helpers remain tracked in git

## What changed / Why
- created `scripts/lib/sdd-common.sh` so SDD-related shell tooling can reuse a consistent slugification routine that matches the Python implementation while using extended regular expressions for portability
- added a direct self-test snippet to document and verify the expected transformation of mixed-case, punctuated feature names
- adjusted `.gitignore` to explicitly include `scripts/lib/` so these shared helpers are version controlled instead of being skipped by the top-level `lib/` rule

## Risks
- Low: new helper script is isolated and only executes its self-test when run directly; no existing runtime paths reference it yet.

## Test coverage
- Added a built-in self-test for `slugify` executed when the helper is invoked directly.

## Verification
- `pre-commit run --all-files` *(fails: repository contains numerous pre-existing lint/type issues and formatting errors outside the touched files)*
- `pytest -q tests/runtime` *(fails: environment raises `ImportError: cannot import name 'FixtureDef'` from pytest plugins)*

## Runtime impact
- None: change only introduces an optional shell helper and does not alter runtime code paths, latency, retries, or schema enforcement.

## Observability
- None: no telemetry, logging, or event schema changes.

## Rollback
- Revert commit `scripts: add sdd slugify helper` and remove the `.gitignore` exceptions for `scripts/lib/`.


------
https://chatgpt.com/codex/tasks/task_e_68c87a05eaa88328bc84651d17c1776e

## Summary by Sourcery

Provide a reusable slugify shell function aligned with the Python implementation, include a built-in verification test, and ensure the helper is version controlled.

New Features:
- Add shared "scripts/lib/sdd-common.sh" with a slugify helper for SDD shell tooling

Tests:
- Include a basic self-test for the slugify function when the script is run directly

Chores:
- Adjust .gitignore to unignore and track the scripts/lib directory