### PR TITLE
[runtime] Capture validation messages as JSON

### DIFF
--- a/scripts/collect_validation_messages.sh
+++ b/scripts/collect_validation_messages.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+#
+# Collect repository validation messages and emit JSON for downstream tooling.
+#
+# Usage:
+#   bash scripts/collect_validation_messages.sh
+#
+# Verification steps:
+#   1. Run the script from the repository root.
+#   2. Ensure the printed JSON payload contains at least three entries.
+#   3. Confirm each message string is distinct so consumers can render
+#      actionable feedback.
+#
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "${SCRIPT_DIR}/.." && pwd)
+cd "${REPO_ROOT}"
+
+validation_messages=()
+error_count=0
+
+add_message() {
+  local status=$1
+  local message=$2
+  validation_messages+=("${status}::${message}")
+  if [[ ${status} == "error" ]]; then
+    ((error_count++))
+  fi
+}
+
+# Check: streaming orchestrator module present
+if [[ -f "src/reug_runtime/router.py" ]]; then
+  add_message "info" "reug_runtime/router.py present for streaming orchestration"
+else
+  add_message "error" "Missing streaming orchestrator module src/reug_runtime/router.py"
+fi
+
+# Check: router parser still recognises tool_call tags
+if grep -q "<tool_call>" "src/reug_runtime/router.py"; then
+  add_message "info" "Streaming router parses <tool_call> tags"
+else
+  add_message "warning" "Streaming router missing <tool_call> parser"
+fi
+
+# Check: runtime tests cover streaming smoke path
+if [[ -f "tests/runtime/test_router_smoke.py" ]]; then
+  add_message "info" "tests/runtime/test_router_smoke.py available for regression coverage"
+else
+  add_message "error" "Missing runtime smoke test for router"
+fi
+
+# Check: PATCHMAP documents streaming orchestrator behaviour
+if grep -iq "streaming orchestrator" "PATCHMAP.md"; then
+  add_message "info" "PATCHMAP.md documents the streaming orchestrator contract"
+else
+  add_message "warning" "PATCHMAP.md missing streaming orchestrator documentation"
+fi
+
+PYTHON_BIN=${PYTHON_BIN:-python3}
+if ! command -v "${PYTHON_BIN}" >/dev/null 2>&1; then
+  if command -v python >/dev/null 2>&1; then
+    PYTHON_BIN=python
+  else
+    echo "Python interpreter not found" >&2
+    exit 1
+  fi
+fi
+
+JSON_OUTPUT=$("${PYTHON_BIN}" "${SCRIPT_DIR}/validation_messages_to_json.py" "${validation_messages[@]}")
+printf '%s\n' "${JSON_OUTPUT}"
+exit ${error_count}

--- a/scripts/collect_validation_messages.sh
+++ b/scripts/collect_validation_messages.sh
@@ -68,5 +68,10 @@ if ! command -v "${PYTHON_BIN}" >/dev/null 2>&1; then
 fi
 
 JSON_OUTPUT=$("${PYTHON_BIN}" "${SCRIPT_DIR}/validation_messages_to_json.py" "${validation_messages[@]}")
+PYTHON_EXIT_CODE=$?
+if [[ ${PYTHON_EXIT_CODE} -ne 0 ]]; then
+  echo "Error: Python script validation_messages_to_json.py failed with exit code ${PYTHON_EXIT_CODE}" >&2
+  exit 1
+fi
 printf '%s\n' "${JSON_OUTPUT}"
 exit ${error_count}

--- a/scripts/validation_messages_to_json.py
+++ b/scripts/validation_messages_to_json.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Render validation messages provided via CLI arguments to JSON.
+
+Usage:
+    python scripts/validation_messages_to_json.py status::Message ...
+
+Each positional argument is treated as ``<status>::<message>``.  When the
+status prefix is omitted the message inherits the default status.  The script is
+primarily used by Bash validation harnesses that gather human-friendly strings
+in arrays and need to ship JSON to downstream tooling.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse CLI arguments."""
+
+    parser = argparse.ArgumentParser(
+        description="Convert validation messages to JSON for pipelines",
+    )
+    parser.add_argument(
+        "entries",
+        nargs="*",
+        help=(
+            "Validation messages captured from Bash arrays. Entries use "
+            "'<status>::<message>' format; status defaults to 'info'."
+        ),
+    )
+    parser.add_argument(
+        "--default-status",
+        default="info",
+        help="Status applied when an entry omits the status prefix",
+    )
+    parser.add_argument(
+        "--indent",
+        type=int,
+        default=2,
+        help="Indentation level for the JSON payload",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Entry point."""
+
+    args = parse_args()
+    repo_root = Path(__file__).resolve().parents[1]
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+
+    from src.utils.validation_output import to_json
+
+    payload = to_json(
+        args.entries, default_status=args.default_status, indent=args.indent
+    )
+    sys.stdout.write(payload + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/utils/validation_output.py
+++ b/src/utils/validation_output.py
@@ -1,0 +1,87 @@
+"""Utilities for turning validation messages into structured JSON payloads.
+
+The REUG runtime surfaces validation or health-check messages in a variety of
+places (shell scripts, CI jobs, orchestration tools).  Bash is convenient for
+running the checks, but JSON is the lingua franca for telemetry and pipeline
+consumers.  These helpers keep the transformation small, well-tested, and
+reusable.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Sequence
+from typing import Any
+
+DEFAULT_STATUS = "info"
+
+
+def _split_status(entry: str, default_status: str = DEFAULT_STATUS) -> tuple[str, str]:
+    """Split a raw ``status::message`` entry.
+
+    Args:
+        entry: Raw message captured by a shell script.  Expected format is
+            ``"<status>::<message>"`` but the status prefix is optional.
+        default_status: Status value applied when ``entry`` has no explicit
+            prefix.
+
+    Returns:
+        Tuple of ``(status, message)`` with surrounding whitespace trimmed and
+        status normalised to lowercase.
+    """
+
+    if "::" in entry:
+        status_part, message = entry.split("::", 1)
+        status = status_part.strip().lower() or default_status
+    else:
+        status, message = default_status, entry
+    return status, message.strip()
+
+
+def normalise_messages(
+    entries: Sequence[str], default_status: str = DEFAULT_STATUS
+) -> list[dict[str, str | int]]:
+    """Normalise raw validation entries into structured dictionaries.
+
+    Args:
+        entries: Ordered collection of raw messages (usually from Bash arrays).
+        default_status: Default status assigned to entries without a status
+            prefix.
+
+    Returns:
+        List of dictionaries in the form ``{"index": n, "status": s, "message": m}``
+        with blank entries removed.
+    """
+
+    records: list[dict[str, str | int]] = []
+    for idx, raw in enumerate(entries, start=1):
+        trimmed = raw.strip()
+        if not trimmed:
+            continue
+        status, message = _split_status(trimmed, default_status=default_status)
+        records.append({"index": idx, "status": status, "message": message})
+    return records
+
+
+def build_payload(
+    entries: Sequence[str], default_status: str = DEFAULT_STATUS
+) -> dict[str, Any]:
+    """Create a JSON-serialisable payload describing validation messages."""
+
+    records = normalise_messages(entries, default_status=default_status)
+    return {"count": len(records), "messages": records}
+
+
+def to_json(
+    entries: Sequence[str],
+    *,
+    default_status: str = DEFAULT_STATUS,
+    indent: int = 2,
+) -> str:
+    """Render validation messages as JSON."""
+
+    payload = build_payload(entries, default_status=default_status)
+    return json.dumps(payload, indent=indent)
+
+
+__all__ = ["build_payload", "normalise_messages", "to_json"]

--- a/tests/runtime/test_validation_messages_script.py
+++ b/tests/runtime/test_validation_messages_script.py
@@ -1,0 +1,33 @@
+"""Integration test for collect_validation_messages.sh."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "collect_validation_messages.sh"
+
+
+def test_collect_validation_messages_outputs_distinct_entries() -> None:
+    result = subprocess.run(
+        ["bash", str(SCRIPT_PATH)],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+
+    assert payload["count"] >= 3
+    messages = payload["messages"]
+    assert len(messages) == payload["count"]
+
+    texts = [entry["message"] for entry in messages]
+    assert len(set(texts)) == len(texts)
+
+    statuses = {entry["status"] for entry in messages}
+    assert statuses.issubset({"info", "warning", "error"})

--- a/tests/runtime/test_validation_output_helper.py
+++ b/tests/runtime/test_validation_output_helper.py
@@ -1,0 +1,35 @@
+"""Tests for validation message normalisation utilities."""
+
+from __future__ import annotations
+
+import json
+
+from src.utils.validation_output import build_payload, normalise_messages, to_json
+
+
+def test_normalise_messages_parses_status_prefixes() -> None:
+    entries = [
+        "error::Missing required field",  # explicit status
+        " warning ::Leading whitespace trimmed",  # whitespace handling
+        "Plain message without status",  # inherits default status
+        "",  # skipped entirely
+    ]
+
+    records = normalise_messages(entries)
+    assert [r["status"] for r in records] == ["error", "warning", "info"]
+    assert [r["index"] for r in records] == [1, 2, 3]
+    assert records[0]["message"] == "Missing required field"
+    assert records[1]["message"] == "Leading whitespace trimmed"
+    assert records[2]["message"] == "Plain message without status"
+
+
+def test_build_payload_and_to_json_round_trip() -> None:
+    entries = ["info::Router healthy", "warning::Schema enforcement disabled"]
+
+    payload = build_payload(entries)
+    assert payload["count"] == 2
+    assert len(payload["messages"]) == 2
+
+    json_output = to_json(entries)
+    as_dict = json.loads(json_output)
+    assert as_dict == payload


### PR DESCRIPTION
## Summary
- add a bash harness that collects validation messages, runs basic REUG router checks, and emits JSON for downstream tooling
- provide a small Python helper/CLI to normalise `<status>::message` entries into structured JSON
- cover the helper and script with runtime tests that assert multiple distinct messages are present in the generated payload

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/runtime/test_validation_output_helper.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/runtime/test_validation_messages_script.py
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/runtime *(fails: existing FastAPI response model annotation issues)*
- pre-commit run --all-files *(fails: repository-wide lint/format errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68c87b89fbc48328acd97830dd8b3dc5

## Summary by Sourcery

Introduce a JSON-based validation pipeline by adding Python helpers for structuring messages, a Bash harness for collecting REUG runtime checks, and a CLI script to emit JSON, with accompanying unit and integration tests.

New Features:
- Add Python utilities to normalise status::message entries and build JSON payloads for validation messages
- Introduce a Bash script to perform REUG router validation checks and emit JSON-formatted messages
- Provide a standalone Python CLI script to render validation message arrays as JSON

Tests:
- Add unit tests for the Python validation helpers to verify message parsing and JSON round-trip
- Add an integration test for the Bash harness to ensure distinct validation messages, correct status values, and a non-error exit code