### PR TITLE
scripts: add sdd bootstrap scripts

### DIFF
--- a/scripts/check-task-prerequisites.sh
+++ b/scripts/check-task-prerequisites.sh
@@ -85,7 +85,7 @@ fi
 if [[ -f "${DATA_MODEL}" ]]; then
     has_data_model=1
 fi
-if [[ -d "${CONTRACTS_DIR}" ]] && [[ -n "$(ls -A "${CONTRACTS_DIR}" 2>/dev/null)" ]]; then
+if [[ -d "${CONTRACTS_DIR}" ]] && [[ -n "$(find "${CONTRACTS_DIR}" -mindepth 1 -print -quit 2>/dev/null)" ]]; then
     has_contracts=1
 fi
 if [[ -f "${QUICKSTART}" ]]; then

--- a/scripts/check-task-prerequisites.sh
+++ b/scripts/check-task-prerequisites.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# check-task-prerequisites.sh - Validate required artifacts before task generation.
+# Usage: ./scripts/check-task-prerequisites.sh [--json]
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=scripts/lib/sdd-common.sh
+source "${SCRIPT_DIR}/lib/sdd-common.sh"
+
+print_usage() {
+    cat <<'USAGE'
+Usage: ./scripts/check-task-prerequisites.sh [--json]
+USAGE
+}
+
+JSON_MODE=false
+for arg in "$@"; do
+    case "$arg" in
+        --json)
+            JSON_MODE=true
+            ;;
+        --help|-h)
+            print_usage
+            exit 0
+            ;;
+    esac
+done
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if ! require_feature_branch "${CURRENT_BRANCH}"; then
+    exit 1
+fi
+
+FEATURE_DIR="${REPO_ROOT}/specs/${CURRENT_BRANCH}"
+PRIMARY_SPEC="${FEATURE_DIR}/feature-spec.md"
+LEGACY_SPEC="${FEATURE_DIR}/spec.md"
+PRIMARY_PLAN="${FEATURE_DIR}/plan.md"
+LEGACY_PLAN="${FEATURE_DIR}/implementation-plan.md"
+RESEARCH="${FEATURE_DIR}/research.md"
+DATA_MODEL="${FEATURE_DIR}/data-model.md"
+QUICKSTART="${FEATURE_DIR}/quickstart.md"
+CONTRACTS_DIR="${FEATURE_DIR}/contracts"
+
+if [[ ! -d "${FEATURE_DIR}" ]]; then
+    if ${JSON_MODE}; then
+        missing_json=$(sdd_json_array "feature-spec.md" "plan.md")
+        printf '{"ok":false,"missing":%s}\n' "${missing_json}"
+    else
+        printf 'ERROR: Feature directory not found: %s\n' "${FEATURE_DIR}"
+        printf 'Run /specify first to create the feature structure.\n'
+    fi
+    exit 1
+fi
+
+failures=()
+feature_spec_found=0
+plan_found=0
+
+if [[ -f "${PRIMARY_SPEC}" ]]; then
+    feature_spec_found=1
+elif [[ -f "${LEGACY_SPEC}" ]]; then
+    feature_spec_found=1
+else
+    failures+=("feature-spec.md")
+fi
+
+if [[ -f "${PRIMARY_PLAN}" ]]; then
+    plan_found=1
+elif [[ -f "${LEGACY_PLAN}" ]]; then
+    plan_found=1
+else
+    failures+=("plan.md")
+fi
+
+has_research=0
+has_data_model=0
+has_contracts=0
+has_quickstart=0
+
+if [[ -f "${RESEARCH}" ]]; then
+    has_research=1
+fi
+if [[ -f "${DATA_MODEL}" ]]; then
+    has_data_model=1
+fi
+if [[ -d "${CONTRACTS_DIR}" ]] && [[ -n "$(ls -A "${CONTRACTS_DIR}" 2>/dev/null)" ]]; then
+    has_contracts=1
+fi
+if [[ -f "${QUICKSTART}" ]]; then
+    has_quickstart=1
+fi
+
+if ${JSON_MODE}; then
+    ok_value="true"
+    if ((${#failures[@]} > 0)); then
+        ok_value="false"
+    fi
+    missing_json=$(sdd_json_array "${failures[@]}")
+    printf '{"ok":%s,"missing":%s}\n' "${ok_value}" "${missing_json}"
+else
+    printf 'FEATURE_DIR:%s\n' "${FEATURE_DIR}"
+    printf 'REQUIRED:\n'
+    if ((feature_spec_found)); then
+        printf '  \u2713 feature-spec.md\n'
+    else
+        printf '  \u2717 feature-spec.md\n'
+    fi
+    if ((plan_found)); then
+        printf '  \u2713 plan.md\n'
+    else
+        printf '  \u2717 plan.md\n'
+    fi
+
+    printf '\nAVAILABLE_DOCS:\n'
+    if ((has_research)); then
+        printf '  \u2713 research.md\n'
+    else
+        printf '  \u2717 research.md\n'
+    fi
+    if ((has_data_model)); then
+        printf '  \u2713 data-model.md\n'
+    else
+        printf '  \u2717 data-model.md\n'
+    fi
+    if ((has_contracts)); then
+        printf '  \u2713 contracts/\n'
+    else
+        printf '  \u2717 contracts/\n'
+    fi
+    if ((has_quickstart)); then
+        printf '  \u2713 quickstart.md\n'
+    else
+        printf '  \u2717 quickstart.md\n'
+    fi
+
+    if ((feature_spec_found == 0)); then
+        printf 'ERROR: feature-spec.md not found in %s\n' "${FEATURE_DIR}"
+        printf 'Run /specify first to create the feature structure.\n'
+    fi
+    if ((plan_found == 0)); then
+        printf 'ERROR: plan.md not found in %s\n' "${FEATURE_DIR}"
+        printf 'Run /plan first to create the plan.\n'
+    fi
+fi
+
+if ((${#failures[@]} > 0)); then
+    exit 1
+fi

--- a/scripts/create-new-feature.sh
+++ b/scripts/create-new-feature.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# create-new-feature.sh - Bootstrap a new feature branch and spec template.
+# Usage: ./scripts/create-new-feature.sh [--json] <feature description>
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=scripts/lib/sdd-common.sh
+source "${SCRIPT_DIR}/lib/sdd-common.sh"
+
+print_usage() {
+    cat <<'USAGE'
+Usage: ./scripts/create-new-feature.sh [--json] <feature description>
+USAGE
+}
+
+JSON_MODE=false
+ARGS=()
+for arg in "$@"; do
+    case "$arg" in
+        --json)
+            JSON_MODE=true
+            ;;
+        --help|-h)
+            print_usage
+            exit 0
+            ;;
+        *)
+            ARGS+=("$arg")
+            ;;
+    esac
+done
+
+if ((${#ARGS[@]} == 0)); then
+    print_usage >&2
+    exit 1
+fi
+
+FEATURE_DESCRIPTION="${ARGS[*]}"
+REPO_ROOT=$(git rev-parse --show-toplevel)
+SPECS_DIR="${REPO_ROOT}/specs"
+mkdir -p "${SPECS_DIR}"
+
+HIGHEST=0
+if compgen -G "${SPECS_DIR}/*" >/dev/null; then
+    for entry in "${SPECS_DIR}"/*; do
+        [[ -d "${entry}" ]] || continue
+        basename=$(basename "${entry}")
+        if [[ "${basename}" =~ ^([0-9]+) ]]; then
+            number=${BASH_REMATCH[1]}
+            number=$((10#${number}))
+            if ((number > HIGHEST)); then
+                HIGHEST=${number}
+            fi
+        fi
+    done
+fi
+
+NEXT=$((HIGHEST + 1))
+FEATURE_NUM=$(printf "%03d" "${NEXT}")
+
+SLUG=$(slugify "${FEATURE_DESCRIPTION}")
+if [[ -z "${SLUG}" ]]; then
+    SLUG="feature"
+fi
+
+IFS='-' read -r -a SLUG_PARTS <<<"${SLUG}"
+SELECTED=()
+for part in "${SLUG_PARTS[@]}"; do
+    [[ -z "${part}" ]] && continue
+    SELECTED+=("${part}")
+    if ((${#SELECTED[@]} == 3)); then
+        break
+    fi
+done
+
+if ((${#SELECTED[@]} == 0)); then
+    SELECTED=("feature")
+fi
+
+BRANCH_SUFFIX=$(IFS=-; echo "${SELECTED[*]}")
+BRANCH_NAME="${FEATURE_NUM}-${BRANCH_SUFFIX}"
+
+git checkout -b "${BRANCH_NAME}"
+
+FEATURE_DIR="${SPECS_DIR}/${BRANCH_NAME}"
+mkdir -p "${FEATURE_DIR}"
+
+TEMPLATE="${REPO_ROOT}/templates/spec-template.md"
+SPEC_FILE="${FEATURE_DIR}/spec.md"
+
+if [[ -f "${TEMPLATE}" ]]; then
+    cp "${TEMPLATE}" "${SPEC_FILE}"
+else
+    printf 'Warning: Template not found at %s\n' "${TEMPLATE}" >&2
+    : >"${SPEC_FILE}"
+fi
+
+if ${JSON_MODE}; then
+    printf '{"BRANCH_NAME":"%s","SPEC_FILE":"%s","FEATURE_NUM":"%s"}\n' \
+        "${BRANCH_NAME}" "${SPEC_FILE}" "${FEATURE_NUM}"
+else
+    printf 'BRANCH_NAME: %s\n' "${BRANCH_NAME}"
+    printf 'SPEC_FILE: %s\n' "${SPEC_FILE}"
+    printf 'FEATURE_NUM: %s\n' "${FEATURE_NUM}"
+fi

--- a/scripts/lib/sdd-common.sh
+++ b/scripts/lib/sdd-common.sh
@@ -2,7 +2,8 @@
 set -euo pipefail
 
 # Common helper utilities for SDD shell tooling.
-# Provides a slugify helper that mirrors the Python implementation.
+# Provides helpers shared across bash entrypoints that orchestrate
+# specification-driven development workflows.
 slugify() {
     local input="${1:-}"
     if [[ -z "${input}" ]]; then
@@ -17,6 +18,71 @@ slugify() {
         | sed -E 's/^-+|-+$//g')
 
     printf '%s\n' "${slug}"
+}
+
+# Require that the provided branch name follows the standard feature
+# prefix pattern (three digits followed by a hyphenated slug). Emits a
+# helpful error to stderr when the branch name does not match.
+require_feature_branch() {
+    local branch="${1:-}"
+
+    if [[ -z "${branch}" ]]; then
+        echo "ERROR: Branch name is required" >&2
+        return 1
+    fi
+
+    if [[ ! "${branch}" =~ ^[0-9]{3}- ]]; then
+        echo "ERROR: Not on a feature branch. Current branch: ${branch}" >&2
+        echo "Feature branches should be named like: 001-feature-name" >&2
+        return 1
+    fi
+
+    return 0
+}
+
+# Escape a string for safe inclusion inside a JSON string literal. Only
+# covers the characters produced by our CLI tooling (ASCII + newlines).
+sdd_json_escape() {
+    local input="${1-}"
+    local length=${#input}
+    local i char
+
+    for ((i = 0; i < length; i++)); do
+        char=${input:i:1}
+        case "${char}" in
+            '"') printf '\\"' ;;
+            '\\') printf '\\\\' ;;
+            $'\n') printf '\\n' ;;
+            $'\r') printf '\\r' ;;
+            $'\t') printf '\\t' ;;
+            *) printf '%s' "${char}" ;;
+        esac
+    done
+}
+
+# Serialize the provided arguments into a compact JSON array. Values are
+# escaped using the helper above to avoid introducing a jq dependency in
+# lightweight shell scripts.
+sdd_json_array() {
+    if (($# == 0)); then
+        printf '[]'
+        return 0
+    fi
+
+    local first=1
+    printf '['
+    for element in "$@"; do
+        if ((first)); then
+            first=0
+        else
+            printf ','
+        fi
+
+        printf '"'
+        sdd_json_escape "${element}"
+        printf '"'
+    done
+    printf ']'
 }
 
 # Basic self-test when the script is executed directly.

--- a/scripts/lib/sdd-common.sh
+++ b/scripts/lib/sdd-common.sh
@@ -43,7 +43,7 @@ require_feature_branch() {
 # Escape a string for safe inclusion inside a JSON string literal. Only
 # covers the characters produced by our CLI tooling (ASCII + newlines).
 sdd_json_escape() {
-    local input="${1-}"
+    local input="${1:-}"
     local length=${#input}
     local i char
 

--- a/scripts/setup-plan.sh
+++ b/scripts/setup-plan.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# setup-plan.sh - Prepare the implementation plan workspace for the branch.
+# Usage: ./scripts/setup-plan.sh [--json]
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=scripts/lib/sdd-common.sh
+source "${SCRIPT_DIR}/lib/sdd-common.sh"
+
+print_usage() {
+    cat <<'USAGE'
+Usage: ./scripts/setup-plan.sh [--json]
+USAGE
+}
+
+JSON_MODE=false
+for arg in "$@"; do
+    case "$arg" in
+        --json)
+            JSON_MODE=true
+            ;;
+        --help|-h)
+            print_usage
+            exit 0
+            ;;
+    esac
+done
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if ! require_feature_branch "${CURRENT_BRANCH}"; then
+    exit 1
+fi
+
+FEATURE_DIR="${REPO_ROOT}/specs/${CURRENT_BRANCH}"
+FEATURE_SPEC="${FEATURE_DIR}/spec.md"
+IMPL_PLAN="${FEATURE_DIR}/plan.md"
+
+mkdir -p "${FEATURE_DIR}"
+
+TEMPLATE="${REPO_ROOT}/templates/plan-template.md"
+if [[ -f "${TEMPLATE}" ]]; then
+    cp "${TEMPLATE}" "${IMPL_PLAN}"
+fi
+
+if ${JSON_MODE}; then
+    printf '{"FEATURE_SPEC":"%s","IMPL_PLAN":"%s","SPECS_DIR":"%s","BRANCH":"%s"}\n' \
+        "${FEATURE_SPEC}" "${IMPL_PLAN}" "${FEATURE_DIR}" "${CURRENT_BRANCH}"
+else
+    printf 'FEATURE_SPEC: %s\n' "${FEATURE_SPEC}"
+    printf 'IMPL_PLAN: %s\n' "${IMPL_PLAN}"
+    printf 'SPECS_DIR: %s\n' "${FEATURE_DIR}"
+    printf 'BRANCH: %s\n' "${CURRENT_BRANCH}"
+fi

--- a/tests/runtime/test_feature_bootstrap_scripts.py
+++ b/tests/runtime/test_feature_bootstrap_scripts.py
@@ -1,0 +1,127 @@
+import json
+import os
+import subprocess
+from pathlib import Path
+import re
+
+import pytest  # type: ignore[import-not-found]
+
+CREATE_SCRIPT = Path("scripts") / "create-new-feature.sh"
+SETUP_PLAN_SCRIPT = Path("scripts") / "setup-plan.sh"
+
+SPEC_TEMPLATE_TEXT = "# Spec Template\n"
+PLAN_TEMPLATE_TEXT = "# Plan Template\n"
+DEFAULT_DESCRIPTION = "Realtime inference tuning plan"
+
+
+def _run_git_command(repo_dir: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo_dir,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _run_script(script_path: Path, repo_dir: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy() | {
+        "GIT_DIR": str(repo_dir / ".git"),
+        "GIT_WORK_TREE": str(repo_dir),
+    }
+    return subprocess.run(
+        ["bash", str(script_path), *args],
+        cwd=script_path.parent,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _init_repo(tmp_path: Path) -> Path:
+    repo_dir = tmp_path / "feature-repo"
+    repo_dir.mkdir()
+
+    _run_git_command(repo_dir, "init")
+    _run_git_command(repo_dir, "config", "user.email", "test@example.com")
+    _run_git_command(repo_dir, "config", "user.name", "Test User")
+    _run_git_command(repo_dir, "commit", "--allow-empty", "-m", "init")
+
+    templates_dir = repo_dir / "templates"
+    templates_dir.mkdir()
+    (templates_dir / "spec-template.md").write_text(SPEC_TEMPLATE_TEXT, encoding="utf-8")
+    (templates_dir / "plan-template.md").write_text(PLAN_TEMPLATE_TEXT, encoding="utf-8")
+
+    return repo_dir
+
+
+def _slugify(text: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", text.lower()).strip("-")
+    return slug
+
+
+def _branch_suffix(slug: str) -> str:
+    parts = [part for part in slug.split("-") if part]
+    if not parts:
+        return "feature"
+    return "-".join(parts[:3])
+
+
+def test_create_new_feature_generates_branch_and_spec(tmp_path: Path) -> None:
+    repo_dir = _init_repo(tmp_path)
+
+    result = _run_script(CREATE_SCRIPT, repo_dir, "--json", DEFAULT_DESCRIPTION)
+
+    assert result.returncode == 0, result.stderr
+    data = json.loads(result.stdout)
+
+    slug = _slugify(DEFAULT_DESCRIPTION)
+    branch_suffix = _branch_suffix(slug)
+    expected_feature_num = "001"
+    expected_branch = f"{expected_feature_num}-{branch_suffix}"
+    expected_spec = repo_dir / "specs" / expected_branch / "spec.md"
+
+    assert data == {
+        "BRANCH_NAME": expected_branch,
+        "SPEC_FILE": str(expected_spec),
+        "FEATURE_NUM": expected_feature_num,
+    }
+
+    assert expected_spec.exists()
+    assert expected_spec.read_text(encoding="utf-8") == SPEC_TEMPLATE_TEXT
+
+    head_branch = (
+        _run_git_command(repo_dir, "rev-parse", "--abbrev-ref", "HEAD").stdout.strip()
+    )
+    assert head_branch == expected_branch
+
+
+def test_setup_plan_populates_template_and_reports_paths(tmp_path: Path) -> None:
+    repo_dir = _init_repo(tmp_path)
+    create_result = _run_script(CREATE_SCRIPT, repo_dir, "--json", DEFAULT_DESCRIPTION)
+    create_data = json.loads(create_result.stdout)
+    branch_name = create_data["BRANCH_NAME"]
+
+    result = _run_script(SETUP_PLAN_SCRIPT, repo_dir, "--json")
+
+    assert result.returncode == 0, result.stderr
+    data = json.loads(result.stdout)
+
+    feature_dir = repo_dir / "specs" / branch_name
+    expected_spec = feature_dir / "spec.md"
+    expected_plan = feature_dir / "plan.md"
+
+    assert data == {
+        "FEATURE_SPEC": str(expected_spec),
+        "IMPL_PLAN": str(expected_plan),
+        "SPECS_DIR": str(feature_dir),
+        "BRANCH": branch_name,
+    }
+
+    assert expected_plan.exists()
+    assert expected_plan.read_text(encoding="utf-8") == PLAN_TEMPLATE_TEXT
+
+    head_branch = (
+        _run_git_command(repo_dir, "rev-parse", "--abbrev-ref", "HEAD").stdout.strip()
+    )
+    assert head_branch == branch_name

--- a/tests/runtime/test_feature_bootstrap_scripts.py
+++ b/tests/runtime/test_feature_bootstrap_scripts.py
@@ -56,8 +56,23 @@ def _init_repo(tmp_path: Path) -> Path:
 
 
 def _slugify(text: str) -> str:
-    slug = re.sub(r"[^a-z0-9]+", "-", text.lower()).strip("-")
-    return slug
+    """
+    Calls the slugify function from scripts/lib/sdd-common.sh via a subprocess.
+    Assumes that sdd-common.sh defines a slugify function that can be sourced and called.
+    """
+    # Compose a shell command that sources the script and calls slugify
+    # The shell script should print the slugified result to stdout
+    # This assumes sdd-common.sh is in scripts/lib/sdd-common.sh
+    script = (
+        f"source scripts/lib/sdd-common.sh && slugify \"{text}\""
+    )
+    result = subprocess.run(
+        ["bash", "-c", script],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
 
 
 def _branch_suffix(slug: str) -> str:

--- a/tests/runtime/test_task_prerequisites_script.py
+++ b/tests/runtime/test_task_prerequisites_script.py
@@ -7,9 +7,10 @@ from pathlib import Path
 
 import pytest  # type: ignore[import-not-found]
 
-SCRIPT_PATH = (
-    Path("extensions/alita-language-tools") / "scripts" / "check-task-prerequisites.sh"
-)
+SCRIPT_PATHS = [
+    Path("extensions/alita-language-tools") / "scripts" / "check-task-prerequisites.sh",
+    Path("scripts") / "check-task-prerequisites.sh",
+]
 DEFAULT_BRANCH = "001-test-feature"
 EXPECTED_MISSING_JSON = '{"ok":false,"missing":["feature-spec.md","plan.md"]}'
 EXPECTED_OK_JSON = '{"ok":true,"missing":[]}'
@@ -46,8 +47,10 @@ def _init_feature_repo(
     return repo_dir, feature_dir
 
 
-def _run_script(repo_dir: Path, *args: str) -> subprocess.CompletedProcess[str]:
-    if shutil.which("jq") is None:
+def _run_script(
+    script_path: Path, repo_dir: Path, *args: str
+) -> subprocess.CompletedProcess[str]:
+    if "extensions" in script_path.parts and shutil.which("jq") is None:
         pytest.skip("jq is required to run check-task-prerequisites.sh")
 
     env = os.environ.copy() | {
@@ -55,40 +58,45 @@ def _run_script(repo_dir: Path, *args: str) -> subprocess.CompletedProcess[str]:
         "GIT_WORK_TREE": str(repo_dir),
     }
     return subprocess.run(
-        ["bash", str(SCRIPT_PATH), *args],
-        cwd=SCRIPT_PATH.parent,
+        ["bash", str(script_path), *args],
+        cwd=script_path.parent,
         env=env,
         capture_output=True,
         text=True,
     )
 
 
-def test_reports_missing_required_documents(tmp_path: Path) -> None:
+@pytest.mark.parametrize("script_path", SCRIPT_PATHS)
+def test_reports_missing_required_documents(script_path: Path, tmp_path: Path) -> None:
     repo_dir, _ = _init_feature_repo(tmp_path)
 
-    result = _run_script(repo_dir, "--json")
+    result = _run_script(script_path, repo_dir, "--json")
 
     assert result.returncode == 1
     assert result.stdout.strip() == EXPECTED_MISSING_JSON
 
 
-def test_succeeds_when_required_documents_present(tmp_path: Path) -> None:
+@pytest.mark.parametrize("script_path", SCRIPT_PATHS)
+def test_succeeds_when_required_documents_present(
+    script_path: Path, tmp_path: Path
+) -> None:
     repo_dir, feature_dir = _init_feature_repo(tmp_path)
     _write_file(feature_dir / "feature-spec.md", "# Feature spec\n")
     _write_file(feature_dir / "plan.md", "# Plan\n")
 
-    result = _run_script(repo_dir, "--json")
+    result = _run_script(script_path, repo_dir, "--json")
 
     assert result.returncode == 0
     assert result.stdout.strip() == EXPECTED_OK_JSON
 
 
-def test_supports_legacy_file_names(tmp_path: Path) -> None:
+@pytest.mark.parametrize("script_path", SCRIPT_PATHS)
+def test_supports_legacy_file_names(script_path: Path, tmp_path: Path) -> None:
     repo_dir, feature_dir = _init_feature_repo(tmp_path)
     _write_file(feature_dir / "spec.md", "# Legacy spec\n")
     _write_file(feature_dir / "implementation-plan.md", "# Legacy plan\n")
 
-    result = _run_script(repo_dir, "--json")
+    result = _run_script(script_path, repo_dir, "--json")
 
     assert result.returncode == 0
     assert result.stdout.strip() == EXPECTED_OK_JSON


### PR DESCRIPTION
## Summary
- add first-class SDD helper scripts under `scripts/` for feature bootstrap, plan setup, and task prerequisite checks
- extend the shared bash utilities with feature-branch validation plus JSON helpers reused by the new tooling
- add regression coverage exercising the new scripts and re-run prerequisite validation against both script locations

## What changed / Why
- Provide repo-local equivalents of the CLI helpers so contributors can run the SDD flow without the extensions checkout.
- Ensure each script emits the expected JSON contracts (no jq dependency) and reuses a shared helper library for branch validation and JSON encoding.
- Guard the new behavior with pytest coverage that provisions ad-hoc git repos to verify the scripts’ outputs end-to-end.

## Risks
- Shell scripts interact with git state; incorrect logic could create unexpected branches or files when invoked.
- Tests rely on git executable availability in CI environments.

## Test coverage
- Added `tests/runtime/test_feature_bootstrap_scripts.py` covering `create-new-feature.sh` and `setup-plan.sh` JSON output, branch behavior, and template copying.
- Extended `tests/runtime/test_task_prerequisites_script.py` to run against both the existing extension script and the new repository-local script.

## Verification
- `pre-commit run --all-files` *(fails because the repository contains numerous pre-existing lint violations such as trailing whitespace, mixed line endings, YAML/JSON parse errors; see run log)*
- `pytest -q tests/runtime` *(fails in this environment due to an upstream `pytest_asyncio` plugin import error: `ImportError: cannot import name 'FixtureDef' from 'pytest'`)*

## Runtime impact
- None; changes only add developer scripts and tests.

## Observability
- Not applicable; no runtime metrics or telemetry changes.

## Rollback
- Revert commit `scripts: add sdd bootstrap scripts` to remove the new scripts, helper updates, and test adjustments.


------
https://chatgpt.com/codex/tasks/task_e_68c88aae30b083288a370ab3ec9426f5

## Summary by Sourcery

Add repository-local SDD bootstrap scripts for feature creation, plan setup, and prerequisite checks, enhance shared bash utilities with branch validation and JSON helpers, and extend runtime tests to cover the new tooling end-to-end.

New Features:
- Add create-new-feature.sh to bootstrap new feature branches and generate spec templates with JSON output
- Add setup-plan.sh to initialize implementation plan files and report their paths in JSON
- Add check-task-prerequisites.sh to verify required feature artifacts with optional JSON output

Enhancements:
- Extend sdd-common.sh with require_feature_branch validation and sdd_json_escape/sdd_json_array helpers to remove jq dependency

Tests:
- Add runtime tests for create-new-feature.sh and setup-plan.sh covering branch creation, file templates, and JSON contracts
- Parametrize test_task_prerequisites_script.py to run prerequisite checks against both extension-based and new local scripts