### PR TITLE
docs: add codecraft addendum references

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Two equivalent setup paths are provided: Makefile workflow (recommended) or raw 
 
 ### Default Workflow: Specification-Driven Development (SDD)
 
-SDD is the default pipeline for feature work. Start every initiative with `specify → plan → tasks` using the constitutional gates that ship with `src/sdd/`.
+SDD (Specification-Driven Development) is the default pipeline for feature work. Start every initiative with `specify → plan → tasks` using the constitutional gates that ship with `src/sdd/`.
 
 - Use the enhanced CLI: `python -m src.sdd.sdd_cli specify "..."` / `plan` / `tasks`.
 - Shell helpers in `scripts/lib/constitutional-gates.sh` and `scripts/lib/sdd-common.sh` keep bespoke automation aligned with the CMA rules.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ Production-ready architecture with:
 - Modular plugin system
 - OpenAI-compatible local adapter option
 
+## Constitution and Addendum
+
+Super Alita follows a constitutional contract plus a Codecraft addendum that govern every change:
+
+- [Super-Alita Constitutional Framework](.github/CONSTITUTION.md)
+- [Codecraft Addendum (CMA v5.3)](docs/cma-v5.3/codecraft-addendum.md)
+
 ## Key Features
 
 - Event bus with Redis optional backend
@@ -27,6 +34,14 @@ Production-ready architecture with:
 ## Quick Start
 
 Two equivalent setup paths are provided: Makefile workflow (recommended) or raw Python commands.
+
+### Default Workflow: Specification-Driven Development (SDD)
+
+SDD is the default pipeline for feature work. Start every initiative with `specify → plan → tasks` using the constitutional gates that ship with `src/sdd/`.
+
+- Use the enhanced CLI: `python -m src.sdd.sdd_cli specify "..."` / `plan` / `tasks`.
+- Shell helpers in `scripts/lib/constitutional-gates.sh` and `scripts/lib/sdd-common.sh` keep bespoke automation aligned with the CMA rules.
+- Run `scripts/smoke_sdd_specify.py` against a running server to confirm the FastAPI router and gates are healthy before coding.
 
 ### 1. Environment file
 

--- a/docs/cma-v5.3/codecraft-addendum.md
+++ b/docs/cma-v5.3/codecraft-addendum.md
@@ -1,0 +1,24 @@
+# Codecraft Addendum (CMA v5.3)
+
+## Purpose
+This addendum extends the [Super-Alita Constitutional Framework](../../.github/CONSTITUTION.md) with Codecraft-specific operating notes. It preserves the constitutional articles while clarifying how Specification-Driven Development (SDD) powers every Codecraft engagement.
+
+## Mandated Workflow
+- **SDD is the default**. All Codecraft work must begin with `specify → plan → tasks` using the constitutional gates that ship with `src/sdd/`.
+- **No bypassing phases.** Do not generate code before a compliant specification, implementation plan, and task graph are produced.
+- **Constitutional gates stay on.** Requests must keep `constitutional_gates=True`; treat any `compliance_threshold_met=False` result as blocking until the artifacts are revised.
+
+## Tooling Alignment
+- **CLI:** `python -m src.sdd.sdd_cli ...` remains the canonical interface for Codecraft automation. The CLI exposes `specify`, `plan`, `tasks`, and validation helpers wired to the enhanced framework.
+- **Shell helpers:**
+  - `scripts/lib/constitutional-gates.sh` checks specifications and plans for CMA rule coverage (feature IDs, DoD, etc.).
+  - `scripts/lib/sdd-common.sh` provides shared shell helpers (for example, canonical slug generation) so bespoke Codecraft scripts stay consistent with the Python implementation.
+- **Smoke tests:** `scripts/smoke_sdd_specify.py` issues a minimal `/sdd/specify` request against a running runtime to confirm that the constitutional gates and FastAPI wiring are intact.
+
+## Telemetry and Reporting
+- Emit the standard REUG events for every Codecraft turn: `STATE_TRANSITION`, `TaskStarted`, `AbilityCalled/Succeeded/Failed`, and `TaskSucceeded/Failed`. The streaming router must still respect the single terminal event rule.
+- Persist the generated SDD artifacts under `specs/` and capture their hashes in telemetry or task tracking systems so downstream automation can detect drift.
+
+## Change Management
+- Update this addendum whenever CMA articles change or new automation scripts alter the required SDD phase sequencing.
+- Run `pre-commit run --all-files` and `pytest -q tests/runtime` before shipping any Codecraft-facing modification. Treat failures as constitutional blockers until resolved.

--- a/docs/cma-v5.3/codecraft-addendum.md
+++ b/docs/cma-v5.3/codecraft-addendum.md
@@ -13,7 +13,7 @@ This addendum extends the [Super-Alita Constitutional Framework](../../.github/C
 - **Shell helpers:**
   - `scripts/lib/constitutional-gates.sh` checks specifications and plans for CMA rule coverage (feature IDs, DoD, etc.).
   - `scripts/lib/sdd-common.sh` provides shared shell helpers (for example, canonical slug generation) so bespoke Codecraft scripts stay consistent with the Python implementation.
-- **Smoke tests:** `scripts/smoke_sdd_specify.py` issues a minimal `/sdd/specify` request against a running runtime to confirm that the constitutional gates and FastAPI wiring are intact.
+- **Smoke tests:** `scripts/smoke_sdd_specify.py` issues a minimal SDD `/sdd/specify` request against a running runtime to confirm that the constitutional gates and FastAPI wiring are intact.
 
 ## Telemetry and Reporting
 - Emit the standard REUG events for every Codecraft turn: `STATE_TRANSITION`, `TaskStarted`, `AbilityCalled/Succeeded/Failed`, and `TaskSucceeded/Failed`. The streaming router must still respect the single terminal event rule.


### PR DESCRIPTION
## Summary
- add a CMA v5.3 Codecraft addendum describing mandatory SDD sequencing, tooling, and telemetry expectations
- surface links to the constitution and new addendum near the top of the README
- document that SDD is the default Quick Start workflow and point to the helper scripts that enforce the gates

## What changed / Why
- created focused documentation so Codecraft efforts inherit the constitutional guardrails without rediscovering process details
- updated the README to make the constitutional contract visible and to remind contributors that SDD tooling (CLI + shell helpers) is the default path

## Risks
- low: documentation-only changes, but incorrect links would reduce discoverability

## Test coverage
- not applicable (docs only)

## Verification
- `pre-commit run --all-files` *(fails: repository-wide lint violations in legacy files; changes reverted to avoid unrelated edits)*
- `pre-commit run --files README.md docs/cma-v5.3/codecraft-addendum.md` *(pass)*
- `pytest -q tests/runtime` *(fails: upstream pytest/pytest-asyncio version conflict raising ImportError for FixtureDef)*

## Runtime impact
- none

## Observability
- none

## Rollback
- revert this commit

------
https://chatgpt.com/codex/tasks/task_e_68c88ab4bf688328b15e1f34def302c9

## Summary by Sourcery

Add a CMA v5.3 Codecraft addendum and update the README to link to the constitutional framework and document the default Specification-Driven Development workflow with CLI, shell helpers, and smoke tests.

Documentation:
- Introduce a Codecraft addendum (CMA v5.3) detailing mandatory SDD phase sequencing, tooling alignment, telemetry expectations, and change management.
- Surface links to the Super-Alita Constitutional Framework and the new Codecraft addendum near the top of the README.
- Document that Specification-Driven Development is the default workflow for Codecraft and reference the CLI commands, shell helper scripts, and smoke test utility.