### PR TITLE
Ensure constitutional gates script validates jq dependency

### DIFF
--- a/scripts/lib/constitutional-gates.sh
+++ b/scripts/lib/constitutional-gates.sh
@@ -11,8 +11,26 @@ Options:
   --spec PATH   Path to the specification markdown or text file
   --plan PATH   Path to the implementation plan markdown or text file
   -h, --help    Show this message and exit
+
+Dependencies:
+  jq            Command-line JSON processor (https://stedolan.github.io/jq/)
 USAGE
 }
+
+if (($# > 0)); then
+    for arg in "$@"; do
+        if [[ "$arg" == "-h" || "$arg" == "--help" ]]; then
+            usage
+            exit 0
+        fi
+    done
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "error: jq is required by constitutional-gates.sh but was not found in PATH." >&2
+    echo "Install jq from https://stedolan.github.io/jq/ and retry." >&2
+    exit 1
+fi
 
 spec_path=""
 plan_path=""

--- a/tests/runtime/test_constitutional_gates_script.py
+++ b/tests/runtime/test_constitutional_gates_script.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import os
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -49,3 +51,41 @@ def test_reports_success_when_requirements_present(tmp_path: Path) -> None:
     result = run_script(tmp_path, spec_content, plan_content)
 
     assert result == {"ok": True, "messages": []}
+
+
+def test_fails_with_clear_error_when_jq_missing(tmp_path: Path) -> None:
+    """The script should emit a helpful error when jq is unavailable."""
+    spec_file = tmp_path / "spec.md"
+    plan_file = tmp_path / "plan.md"
+    spec_file.write_text("## Spec content\n")
+    plan_file.write_text("## Plan content\n")
+
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+
+    for command_name in ("bash", "cat", "grep"):
+        command_path = shutil.which(command_name)
+        assert command_path is not None, f"{command_name} command not found"
+        (bin_dir / command_name).symlink_to(Path(command_path))
+
+    env = os.environ.copy()
+    env["PATH"] = str(bin_dir)
+
+    completed = subprocess.run(
+        [
+            str(SCRIPT_PATH),
+            "--spec",
+            str(spec_file),
+            "--plan",
+            str(plan_file),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+
+    assert completed.returncode != 0
+    stderr_lower = completed.stderr.lower()
+    assert "jq" in stderr_lower
+    assert "install" in stderr_lower


### PR DESCRIPTION
Summary
- ensure `constitutional-gates.sh` exits early when `jq` is unavailable
- document the `jq` dependency in the script usage help and exercise the failure path with a regression test

What changed / Why
- added a pre-flight guard that checks for `jq`, surfaces a clear installation hint, and keeps `--help` usable without `jq`
- extended the runtime test suite to simulate an environment without `jq` by constraining `PATH` and verifying the new error handling

Risks
- Low: the new guard only triggers when `jq` is missing and the messaging guides remediation.

Test coverage
- New test `test_fails_with_clear_error_when_jq_missing` asserts the error case and complements the existing success path coverage.

Verification
- `pre-commit run --all-files` *(fails: repository baseline triggers extensive Ruff/mypy violations across unrelated files)*
- `pre-commit run --files scripts/lib/constitutional-gates.sh tests/runtime/test_constitutional_gates_script.py` *(fails: mypy hook cannot import `reug_runtime.config` from `tests/runtime/__init__.py` in this environment)*
- `pytest -q tests/runtime` *(fails: pytest_asyncio plugin raises `ImportError` for deprecated `FixtureDef` symbol in bundled pytest)*

Runtime impact
- None; the script now exits sooner when a required tool is missing without affecting runtime services.

Observability
- No telemetry or logging schemas were modified.

Rollback
- Revert commit `scripts: enforce jq requirement`.


------
https://chatgpt.com/codex/tasks/task_e_68c88ab8ea208328805e65fae1c350d1