### PR TITLE
scripts: transliterate slug inputs

### DIFF
--- a/scripts/lib/sdd-common.sh
+++ b/scripts/lib/sdd-common.sh
@@ -11,8 +11,49 @@ slugify() {
         return 0
     fi
 
+    local transliterated
+    if command -v iconv >/dev/null 2>&1; then
+        transliterated=$(printf '%s' "${input}" |
+            iconv -f utf-8 -t ascii//TRANSLIT 2>/dev/null || printf '%s' "${input}")
+    else
+        transliterated=$(python3 - <<'PY' "${input}"
+import sys
+import unicodedata
+
+
+def _transliterate(value: str) -> str:
+    normalized = unicodedata.normalize("NFKD", value)
+    fallback_map = {
+        "ß": "ss",
+        "Ø": "O",
+        "ø": "o",
+        "Đ": "D",
+        "đ": "d",
+        "Ł": "L",
+        "ł": "l",
+        "Æ": "AE",
+        "æ": "ae",
+        "Œ": "OE",
+        "œ": "oe",
+        "Þ": "Th",
+        "þ": "th",
+    }
+    without_marks = []
+    for ch in normalized:
+        if unicodedata.category(ch).startswith("M"):
+            continue
+        without_marks.append(fallback_map.get(ch, ch))
+    ascii_text = "".join(without_marks)
+    return ascii_text.encode("ascii", "ignore").decode("ascii")
+
+
+print(_transliterate(sys.argv[1]), end="")
+PY
+        )
+    fi
+
     local slug
-    slug=$(printf '%s' "${input}" \
+    slug=$(printf '%s' "${transliterated}" \
         | tr '[:upper:]' '[:lower:]' \
         | sed -E 's/[^a-z0-9]+/-/g' \
         | sed -E 's/^-+|-+$//g')

--- a/scripts/lib/sdd-common.sh
+++ b/scripts/lib/sdd-common.sh
@@ -13,8 +13,10 @@ slugify() {
 
     local transliterated
     if command -v iconv >/dev/null 2>&1; then
-        transliterated=$(printf '%s' "${input}" |
-            iconv -f utf-8 -t ascii//TRANSLIT 2>/dev/null || printf '%s' "${input}")
+        transliterated=$(printf '%s' "${input}" | iconv -f utf-8 -t ascii//TRANSLIT 2>/dev/null)
+        if [[ $? -ne 0 || -z "${transliterated}" ]]; then
+            transliterated="${input}"
+        fi
     else
         transliterated=$(python3 - <<'PY' "${input}"
 import sys

--- a/tests/runtime/test_feature_bootstrap_scripts.py
+++ b/tests/runtime/test_feature_bootstrap_scripts.py
@@ -2,7 +2,6 @@ import json
 import os
 import subprocess
 from pathlib import Path
-import re
 
 import pytest  # type: ignore[import-not-found]
 
@@ -24,7 +23,9 @@ def _run_git_command(repo_dir: Path, *args: str) -> subprocess.CompletedProcess[
     )
 
 
-def _run_script(script_path: Path, repo_dir: Path, *args: str) -> subprocess.CompletedProcess[str]:
+def _run_script(
+    script_path: Path, repo_dir: Path, *args: str
+) -> subprocess.CompletedProcess[str]:
     env = os.environ.copy() | {
         "GIT_DIR": str(repo_dir / ".git"),
         "GIT_WORK_TREE": str(repo_dir),
@@ -49,23 +50,26 @@ def _init_repo(tmp_path: Path) -> Path:
 
     templates_dir = repo_dir / "templates"
     templates_dir.mkdir()
-    (templates_dir / "spec-template.md").write_text(SPEC_TEMPLATE_TEXT, encoding="utf-8")
-    (templates_dir / "plan-template.md").write_text(PLAN_TEMPLATE_TEXT, encoding="utf-8")
+    (templates_dir / "spec-template.md").write_text(
+        SPEC_TEMPLATE_TEXT, encoding="utf-8"
+    )
+    (templates_dir / "plan-template.md").write_text(
+        PLAN_TEMPLATE_TEXT, encoding="utf-8"
+    )
 
     return repo_dir
 
 
 def _slugify(text: str) -> str:
     """
-    Calls the slugify function from scripts/lib/sdd-common.sh via a subprocess.
-    Assumes that sdd-common.sh defines a slugify function that can be sourced and called.
+    Call the slugify function from scripts/lib/sdd-common.sh via a subprocess.
+
+    Assumes that the sourced script defines a slugify helper.
     """
     # Compose a shell command that sources the script and calls slugify
     # The shell script should print the slugified result to stdout
     # This assumes sdd-common.sh is in scripts/lib/sdd-common.sh
-    script = (
-        f"source scripts/lib/sdd-common.sh && slugify \"{text}\""
-    )
+    script = f'source scripts/lib/sdd-common.sh && slugify "{text}"'
     result = subprocess.run(
         ["bash", "-c", script],
         capture_output=True,
@@ -73,6 +77,17 @@ def _slugify(text: str) -> str:
         check=True,
     )
     return result.stdout.strip()
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("München", "munchen"),
+        ("Straße", "strasse"),
+    ],
+)
+def test_slugify_transliterates_unicode_characters(text: str, expected: str) -> None:
+    assert _slugify(text) == expected
 
 
 def _branch_suffix(slug: str) -> str:
@@ -105,9 +120,9 @@ def test_create_new_feature_generates_branch_and_spec(tmp_path: Path) -> None:
     assert expected_spec.exists()
     assert expected_spec.read_text(encoding="utf-8") == SPEC_TEMPLATE_TEXT
 
-    head_branch = (
-        _run_git_command(repo_dir, "rev-parse", "--abbrev-ref", "HEAD").stdout.strip()
-    )
+    head_branch = _run_git_command(
+        repo_dir, "rev-parse", "--abbrev-ref", "HEAD"
+    ).stdout.strip()
     assert head_branch == expected_branch
 
 
@@ -136,7 +151,7 @@ def test_setup_plan_populates_template_and_reports_paths(tmp_path: Path) -> None
     assert expected_plan.exists()
     assert expected_plan.read_text(encoding="utf-8") == PLAN_TEMPLATE_TEXT
 
-    head_branch = (
-        _run_git_command(repo_dir, "rev-parse", "--abbrev-ref", "HEAD").stdout.strip()
-    )
+    head_branch = _run_git_command(
+        repo_dir, "rev-parse", "--abbrev-ref", "HEAD"
+    ).stdout.strip()
     assert head_branch == branch_name


### PR DESCRIPTION
## Summary
- normalize slug inputs through iconv or a Python unicodedata fallback before ASCII cleanup
- add focused regression for slugifying non-ASCII text in the bootstrap script tests

## What changed / Why
- ensure feature slugs stay stable when users provide Unicode characters (e.g., München, Straße)
- introduce test coverage so regressions in shell slug normalization are caught early

## Risks
- slight behavior shift for existing Unicode-heavy feature names (non-ASCII letters now transliterate instead of being dropped)

## Test coverage
- tests/runtime/test_feature_bootstrap_scripts.py

## Verification
- `SKIP=mypy pre-commit run --files scripts/lib/sdd-common.sh tests/runtime/test_feature_bootstrap_scripts.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/runtime` *(fails: FastAPI response model errors in baseline suite)*

## Runtime impact
- none; change only touches helper shell script

## Observability
- no telemetry changes required

## Rollback
- revert commit `scripts: transliterate slug inputs`


------
https://chatgpt.com/codex/tasks/task_e_68c8920f88488328ae6ea79196473b70

## Summary by Sourcery

Introduce transliteration for Unicode in the slugify helper and add regression tests for non-ASCII inputs in the bootstrap scripts

Enhancements:
- Transliterate Unicode characters in slugify using iconv if available or a Python unicodedata fallback before ASCII cleanup to preserve non-ASCII input

Tests:
- Add parametrized regression tests in test_feature_bootstrap_scripts.py to verify slugification of Unicode text (e.g., München → munchen, Straße → strasse)