### PR TITLE
[report] decouple template generation

### DIFF
--- a/docs/deep-dive/REPORT.tpl.md
+++ b/docs/deep-dive/REPORT.tpl.md
@@ -1,5 +1,5 @@
 # super-alita — Deep Dive Report
-**Date:** 2025-09-15 | **Commit:** 643e8a1 | **Repo Size:** 1855 files / 560790 LOC
+**Date:** <fill> | **Commit:** <sha> | **Repo Size:** <files/LOC>
 
 ## Executive Summary
 - Architecture & key components:

--- a/kpi-ratchet.py
+++ b/kpi-ratchet.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Generate the deep dive report from the static template."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+REPO_ROOT = Path(__file__).resolve().parent
+DEFAULT_TEMPLATE_PATH = REPO_ROOT / "docs" / "deep-dive" / "REPORT.tpl.md"
+DEFAULT_OUTPUT_PATH = REPO_ROOT / "docs" / "deep-dive" / "REPORT.md"
+
+
+@dataclass(frozen=True)
+class ReportContext:
+    """Values that are interpolated into the report template."""
+
+    date: str
+    commit_sha: str
+    file_count: int
+    loc_count: int
+
+    @property
+    def repo_size_label(self) -> str:
+        """Display representation for the "Repo Size" placeholder."""
+
+        return f"{self.file_count} files / {self.loc_count} LOC"
+
+
+def load_template(path: Path) -> str:
+    """Load the template contents from ``path``."""
+
+    return path.read_text(encoding="utf-8")
+
+
+def write_report(path: Path, content: str) -> None:
+    """Persist ``content`` to ``path`` using UTF-8 encoding."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _run_git_command(args: Iterable[str], repo_root: Path) -> str | None:
+    """Execute a git command relative to ``repo_root`` and return trimmed output."""
+
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+    return result.stdout.strip()
+
+
+def _tracked_files(repo_root: Path) -> list[str]:
+    """Return the list of tracked files for ``repo_root``."""
+
+    output = _run_git_command(["ls-files"], repo_root)
+    if output is None:
+        return []
+    return [line for line in output.splitlines() if line]
+
+
+def _count_lines(repo_root: Path, files: Iterable[str]) -> int:
+    """Count the total number of lines contained in ``files`` relative to ``repo_root``."""
+
+    total = 0
+    for relative_path in files:
+        path = repo_root / relative_path
+        try:
+            with path.open("r", encoding="utf-8", errors="ignore") as handle:
+                total += sum(1 for _ in handle)
+        except OSError:
+            # Skip files that cannot be opened (e.g., removed or permission issues).
+            continue
+    return total
+
+
+def build_context(repo_root: Path) -> ReportContext:
+    """Construct the context injected into the template."""
+
+    date = datetime.now(timezone.utc).date().isoformat()
+    commit_sha = _run_git_command(["rev-parse", "--short", "HEAD"], repo_root) or "unknown"
+    tracked = _tracked_files(repo_root)
+    file_count = len(tracked)
+    loc_count = _count_lines(repo_root, tracked)
+    return ReportContext(date=date, commit_sha=commit_sha, file_count=file_count, loc_count=loc_count)
+
+
+def fill_template(template: str, context: ReportContext) -> str:
+    """Replace placeholder tokens in ``template`` using ``context`` values."""
+
+    replacements = {
+        "<fill>": context.date,
+        "<sha>": context.commit_sha,
+        "<files/LOC>": context.repo_size_label,
+    }
+    rendered = template
+    for placeholder, value in replacements.items():
+        rendered = rendered.replace(placeholder, value)
+    return rendered
+
+
+def generate_report(
+    *,
+    template_path: Path = DEFAULT_TEMPLATE_PATH,
+    output_path: Path = DEFAULT_OUTPUT_PATH,
+    repo_root: Path | None = None,
+) -> Path:
+    """Generate the report using ``template_path`` and write it to ``output_path``."""
+
+    resolved_repo_root = repo_root or REPO_ROOT
+    template = load_template(template_path)
+    context = build_context(resolved_repo_root)
+    rendered = fill_template(template, context)
+    write_report(output_path, rendered)
+    return output_path
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse CLI arguments for the generator."""
+
+    parser = argparse.ArgumentParser(description="Generate the deep dive KPI report.")
+    parser.add_argument(
+        "--template",
+        type=Path,
+        default=DEFAULT_TEMPLATE_PATH,
+        help="Path to the report template.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=DEFAULT_OUTPUT_PATH,
+        help="Path where the rendered report should be written.",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=REPO_ROOT,
+        help="Repository root used for gathering metadata.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Entry point for the CLI."""
+
+    args = parse_args()
+    generate_report(
+        template_path=args.template,
+        output_path=args.output,
+        repo_root=args.repo_root,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/kpi-ratchet.py
+++ b/kpi-ratchet.py
@@ -64,9 +64,7 @@ def _tracked_files(repo_root: Path) -> list[str]:
     """Return the list of tracked files for ``repo_root``."""
 
     output = _run_git_command(["ls-files"], repo_root)
-    if output is None:
-        return []
-    return [line for line in output.splitlines() if line]
+    return [] if output is None else [line for line in output.splitlines() if line]
 
 
 def _count_lines(repo_root: Path, files: Iterable[str]) -> int:

--- a/tests/test_kpi_ratchet.py
+++ b/tests/test_kpi_ratchet.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import subprocess
+from datetime import date
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+def load_kpi_ratchet() -> ModuleType:
+    module_path = Path(__file__).resolve().parents[1] / "kpi-ratchet.py"
+    spec = importlib.util.spec_from_file_location("kpi_ratchet_module", module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("Unable to load kpi-ratchet module")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture()
+def kpi_ratchet() -> ModuleType:
+    return load_kpi_ratchet()
+
+
+def test_generate_report_uses_template(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, kpi_ratchet: ModuleType
+) -> None:
+    template_path = tmp_path / "REPORT.tpl.md"
+    template_path.write_text(
+        "Date: <fill> | Commit: <sha> | Size: <files/LOC>\n",
+        encoding="utf-8",
+    )
+    output_path = tmp_path / "REPORT.md"
+
+    context = kpi_ratchet.ReportContext(
+        date="2024-01-02",
+        commit_sha="abc1234",
+        file_count=4,
+        loc_count=200,
+    )
+    monkeypatch.setattr(kpi_ratchet, "build_context", lambda repo_root: context)
+
+    generated_path = kpi_ratchet.generate_report(
+        template_path=template_path,
+        output_path=output_path,
+        repo_root=tmp_path,
+    )
+
+    assert generated_path == output_path
+    assert output_path.read_text(encoding="utf-8") == "Date: 2024-01-02 | Commit: abc1234 | Size: 4 files / 200 LOC\n"
+    # Ensure the template remained untouched.
+    assert template_path.read_text(encoding="utf-8") == "Date: <fill> | Commit: <sha> | Size: <files/LOC>\n"
+
+
+def test_build_context_counts_files(tmp_path: Path, kpi_ratchet: ModuleType) -> None:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir()
+    subprocess.run(["git", "init"], cwd=repo_root, check=True, capture_output=True)
+
+    (repo_root / "alpha.txt").write_text("first\nsecond\n", encoding="utf-8")
+    (repo_root / "bravo.py").write_text("only\n", encoding="utf-8")
+    subprocess.run(["git", "add", "alpha.txt", "bravo.py"], cwd=repo_root, check=True, capture_output=True)
+
+    context = kpi_ratchet.build_context(repo_root)
+
+    assert context.date == date.today().isoformat()
+    assert context.commit_sha == "unknown"
+    assert context.file_count == 2
+    assert context.loc_count == 3
+    assert context.repo_size_label == "2 files / 3 LOC"


### PR DESCRIPTION
## Summary
- move the deep dive template into `docs/deep-dive/REPORT.tpl.md` and keep `REPORT.md` as generated output
- add `kpi-ratchet.py` to load the template, gather repo metadata, and render the report to disk
- add focused tests that validate template substitution and context construction

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/test_kpi_ratchet.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/runtime` *(fails: FastAPI response model errors in baseline)*
- `pre-commit run --all-files` *(fails: repository-wide lint/config issues outside the change scope)*

------
https://chatgpt.com/codex/tasks/task_e_68c8a063feb883288bf4672d58932c40

## Summary by Sourcery

Decouple deep dive report generation by moving the report layout into a template and introducing a CLI generator that fills in repository metadata, accompanied by targeted tests.

New Features:
- Add kpi-ratchet.py CLI to render the deep dive report from a REPORT.tpl.md template with dynamic date, commit SHA, and repo size metadata
- Relocate the report content into docs/deep-dive/REPORT.tpl.md and maintain REPORT.md as generated output

Documentation:
- Introduce REPORT.tpl.md as the new template for the deep dive report

Tests:
- Add tests for template substitution and ReportContext metadata construction