### PR TITLE
core: extend neural atom graph attributes

### DIFF
--- a/src/core/neural_atom.py
+++ b/src/core/neural_atom.py
@@ -82,6 +82,11 @@ class NeuralAtom(ABC):
         # Graph-facing attributes for NeuralStore compatibility
         self.key = key or metadata.name
         self.vector = self._initialize_vector(vector, vector_dim)
+        if self.vector is not None and vector_dim is not None:
+            if len(self.vector) != vector_dim:
+                raise ValueError(
+                    f"Vector length {len(self.vector)} does not match expected dimension {vector_dim}."
+                )
         self.bias = float(bias)
         self.parent_keys = list(parent_keys or [])
         self.children_keys = list(children_keys or [])

--- a/src/core/neural_atom.py
+++ b/src/core/neural_atom.py
@@ -8,7 +8,7 @@ import logging
 import os
 import time
 from abc import ABC, abstractmethod
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any, Generic, TypeVar
@@ -60,10 +60,47 @@ class NeuralAtom(ABC):
     of intelligence containing executable logic, metadata, and semantic embeddings.
     """
 
-    def __init__(self, metadata: NeuralAtomMetadata):
+    DEFAULT_VECTOR_DIM = 128
+
+    def __init__(
+        self,
+        metadata: NeuralAtomMetadata,
+        *,
+        key: str | None = None,
+        vector: np.ndarray | Sequence[float] | None = None,
+        bias: float = 0.0,
+        parent_keys: Sequence[str] | None = None,
+        children_keys: Sequence[str] | None = None,
+        birth_event: str | None = None,
+        lineage_metadata: dict[str, Any] | None = None,
+        vector_dim: int | None = None,
+    ):
         self.metadata = metadata
         self._execution_history: list[dict[str, Any]] = []
         self._semantic_embedding: list[float] | None = None
+
+        # Graph-facing attributes for NeuralStore compatibility
+        self.key = key or metadata.name
+        self.vector = self._initialize_vector(vector, vector_dim)
+        self.bias = float(bias)
+        self.parent_keys = list(parent_keys or [])
+        self.children_keys = list(children_keys or [])
+        self.birth_event = birth_event
+        self.lineage_metadata = dict(lineage_metadata or {})
+
+        # Genealogy helpers
+        self.depth = len(self.parent_keys)
+        self.signature = self._generate_darwin_godel_signature()
+        self.creation_time = datetime.now(UTC)
+        self.last_activation_time = self.creation_time
+        self.activation_count = 0
+        self.fitness_score = 0.0
+
+        # Neural dynamics defaults
+        self.activation_threshold = 0.5
+        self.decay_rate = 0.95
+        self.refractory_period = 0.1
+        self.last_spike_time = 0.0
 
     @abstractmethod
     async def execute(self, input_data: Any) -> Any:
@@ -137,6 +174,54 @@ class NeuralAtom(ABC):
     def average_latency_ms(self) -> float:
         """Return average execution latency in milliseconds."""
         return self.metadata.avg_execution_time * 1000.0
+
+    # --- Graph helper methods ---
+
+    def _initialize_vector(
+        self,
+        vector: np.ndarray | Sequence[float] | None,
+        vector_dim: int | None,
+    ) -> np.ndarray:
+        if vector is not None:
+            vector_array = np.asarray(vector, dtype=np.float32)
+            if vector_array.ndim != 1:
+                raise ValueError("NeuralAtom vector must be one-dimensional")
+            return vector_array
+
+        dim = vector_dim or self.DEFAULT_VECTOR_DIM
+        return np.zeros(dim, dtype=np.float32)
+
+    def _generate_darwin_godel_signature(self) -> str:
+        signature_data = f"{self.key}:{':'.join(sorted(self.parent_keys))}"
+        return hashlib.md5(signature_data.encode()).hexdigest()[:16]
+
+    def add_child(self, child_key: str) -> None:
+        if child_key not in self.children_keys:
+            self.children_keys.append(child_key)
+
+    def add_parent(self, parent_key: str) -> None:
+        if parent_key not in self.parent_keys:
+            self.parent_keys.append(parent_key)
+            self.depth = len(self.parent_keys)
+            self.signature = self._generate_darwin_godel_signature()
+
+    def update_fitness(self, performance_score: float, weight: float = 0.1) -> None:
+        self.fitness_score = (
+            1 - weight
+        ) * self.fitness_score + weight * performance_score
+
+    def get_genealogy_summary(self) -> dict[str, Any]:
+        return {
+            "key": self.key,
+            "signature": self.signature,
+            "depth": self.depth,
+            "parent_count": len(self.parent_keys),
+            "child_count": len(self.children_keys),
+            "creation_time": self.creation_time.isoformat(),
+            "activation_count": self.activation_count,
+            "fitness_score": self.fitness_score,
+            "lineage_metadata": self.lineage_metadata,
+        }
 
 
 # Legacy Neural Atom for backwards compatibility
@@ -431,7 +516,7 @@ class NeuralStore:
         incoming_signals = self._adjacency.T.dot(vectors)
 
         # 3. Apply biases and the non-linear activation function
-        activated_signals = activation_fn(incoming_signals + biases.squeeze())
+        activated_signals = activation_fn(incoming_signals + biases)
 
         # 4. Update the state of all atoms with their new activation vectors
         for i, key in enumerate(self._keys):
@@ -500,7 +585,7 @@ class NeuralStore:
 
         # Collect ancestors and descendants
         def collect_relatives(key: str, depth: int, direction: str):
-            if depth <= 0 or key not in self._atoms:
+            if depth < 0 or key not in self._atoms:
                 return
             atom = self._atoms[key]
             related_keys.add(key)
@@ -1011,7 +1096,6 @@ class TextualMemoryAtom(NeuralAtom):
         super().__init__(metadata)
         # Store additional properties specific to textual memories
         self.content = content
-        self.key = metadata.name  # Add key attribute for NeuralStore compatibility
         self._embedding_client = embedding_client
         self._semantic_embedding = None
         # Generate embedding on creation if client available
@@ -1100,7 +1184,11 @@ class TextualMemoryAtom(NeuralAtom):
                 # Fallback to simple hash-based embedding
                 self._semantic_embedding = self._generate_simple_embedding(self.content)
 
-        return self._semantic_embedding
+        vector_array = np.asarray(self._semantic_embedding, dtype=np.float32)
+        if vector_array.ndim != 1:
+            raise ValueError("TextualMemoryAtom embeddings must be one-dimensional")
+        self.vector = vector_array
+        return list(vector_array)
 
     def can_handle(self, task_description: str) -> float:
         """

--- a/tests/core/test_neural_atom.py
+++ b/tests/core/test_neural_atom.py
@@ -1,15 +1,22 @@
 """Trimmed NeuralAtom tests (post-merge cleanup)."""
 
+import asyncio
+
+import numpy as np
 import pytest
 
-from src.core.neural_atom import NeuralAtom, NeuralAtomMetadata, TextualMemoryAtom
+from src.core.neural_atom import (
+    NeuralAtom,
+    NeuralAtomMetadata,
+    NeuralStore,
+    TextualMemoryAtom,
+)
 
 
 class MockNeuralAtom(NeuralAtom):
     def __init__(self, metadata: NeuralAtomMetadata, test_value: str = "test"):
         super().__init__(metadata)
         self.test_value = test_value
-        self.key = metadata.name
 
     async def execute(self, input_data=None):  # pragma: no cover - trivial
         return {"result": self.test_value, "input": input_data}
@@ -21,16 +28,43 @@ class MockNeuralAtom(NeuralAtom):
         return 0.8 if "test" in task_description.lower() else 0.2
 
 
+class SkillAtom(NeuralAtom):
+    def __init__(
+        self,
+        metadata: NeuralAtomMetadata,
+        instructions: str,
+        activation_scale: float = 0.5,
+    ):
+        vector = (
+            np.ones(NeuralAtom.DEFAULT_VECTOR_DIM, dtype=np.float32) * activation_scale
+        )
+        super().__init__(metadata, vector=vector, bias=0.1)
+        self.instructions = instructions
+
+    async def execute(self, input_data=None):  # pragma: no cover - simple mapping
+        return {
+            "instructions": self.instructions,
+            "input": input_data,
+            "bias": self.bias,
+        }
+
+    def get_embedding(self):  # pragma: no cover - deterministic
+        self.vector = np.asarray(self.vector, dtype=np.float32)
+        return self.vector.tolist()
+
+    def can_handle(self, task_description: str):  # pragma: no cover - simple logic
+        return 1.0 if "skill" in task_description.lower() else 0.3
+
+
 def _md(name: str, caps):
     return NeuralAtomMetadata(name=name, description=name, capabilities=caps)
 
 
-@pytest.mark.asyncio
-async def test_execute_and_safe_metrics():
+def test_execute_and_safe_metrics():
     atom = MockNeuralAtom(_md("exec", ["run"]))
-    res = await atom.execute("x")
+    res = asyncio.run(atom.execute("x"))
     assert res["result"] == "test"
-    safe = await atom.safe_execute("y")
+    safe = asyncio.run(atom.safe_execute("y"))
     assert safe["success"] and atom.metadata.usage_count == 1
 
 
@@ -47,6 +81,50 @@ def test_performance_tracking_updates():
     assert atom.metadata.usage_count == 2
     assert 0 < atom.metadata.success_rate < 1.0
     assert atom.metadata.avg_execution_time > 0
+
+
+def test_neural_store_forward_pass_and_genealogy():
+    store = NeuralStore()
+    text_atom = TextualMemoryAtom(_md("memory_atom", ["memory"]), "stored content")
+    skill_atom = SkillAtom(
+        _md("skill_atom", ["skill", "plan"]),
+        instructions="Do something clever",
+        activation_scale=0.2,
+    )
+
+    store.register(text_atom)
+    store.register(skill_atom)
+    store.add_synapse(text_atom.key, skill_atom.key)
+
+    asyncio.run(store.forward_pass())
+    assert text_atom.activation_count == 1
+    assert skill_atom.activation_count == 1
+
+    child_atom = TextualMemoryAtom(
+        _md("child_memory", ["memory", "history"]),
+        "child content",
+    )
+    store.register_with_lineage(
+        child_atom,
+        parents=[text_atom, skill_atom],
+        birth_event="unit_test_birth",
+        lineage_metadata={"source": "unit_test"},
+    )
+
+    stored_child = store.get(child_atom.key)
+    assert stored_child is child_atom
+    assert set(child_atom.parent_keys) == {text_atom.key, skill_atom.key}
+    assert child_atom.depth == 1 + max(
+        parent.depth for parent in [text_atom, skill_atom]
+    )
+    assert child_atom.key in text_atom.children_keys
+    assert child_atom.key in skill_atom.children_keys
+
+    lineage_related = asyncio.run(
+        store.genealogy_attention(child_atom.key, generations=1)
+    )
+    related_keys = {entry[0] for entry in lineage_related}
+    assert text_atom.key in related_keys
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
## Summary
- extend the base NeuralAtom to own graph-friendly fields and genealogy helpers so NeuralStore operations work uniformly
- update TextualMemoryAtom to sync its embedding vector with the graph state and smooth forward pass bias handling
- add coverage that registers textual and skill atoms in NeuralStore and exercises forward pass plus genealogy linking

## What changed / Why
- ensure all NeuralAtom instances expose key/vector/bias/lineage metadata so registration, attention, and genealogy utilities stop failing when concrete atoms omit those fields
- keep TextualMemoryAtom compatible with the extended base class by normalizing embeddings into numpy vectors for graph math
- regression test that NeuralStore forward_pass and genealogy_attention accept diverse atoms without runtime errors

## Risks
- low: NeuralAtom constructor signature expands; call sites relying on positional arguments may need defaults (all keyword-only)

## Test coverage
- expanded tests/core/test_neural_atom.py to cover NeuralStore registration, forward pass, and genealogy interactions for concrete atoms

## Verification
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/core/test_neural_atom.py` *(pass)*
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/runtime` *(fails: FastAPI router response model incompatibilities in baseline code)*

## Runtime impact
- none expected; NeuralStore forward pass bias broadcasting fixed but keeps previous semantics

## Observability
- no telemetry schema changes; genealogy summaries now consistently available via base class helper

## Rollback
- revert commit `core: unify neural atom graph state`

------
https://chatgpt.com/codex/tasks/task_e_68e36b792390832887186f8a748190f9

## Summary by Sourcery

Extend NeuralAtom to include graph-compatible metadata and genealogy utilities; normalize TextualMemoryAtom embeddings for graph operations; correct forward_pass bias broadcasting and genealogy_attention depth logic; expand tests to cover NeuralStore registration, forward pass, and genealogy linking with TextualMemoryAtom and a new SkillAtom.

New Features:
- Extend NeuralAtom with graph-oriented fields (key, vector, bias, lineage) and genealogy helper methods (add_child, add_parent, update_fitness, genealogy summaries).
- Synchronize TextualMemoryAtom embeddings into numpy vectors for compatibility with graph operations.
- Introduce SkillAtom in tests to validate NeuralStore behaviors.

Bug Fixes:
- Fix bias broadcasting in NeuralStore forward_pass by removing unnecessary squeeze.
- Adjust genealogy_attention depth check to properly include zero-depth relatives.

Tests:
- Expand tests to verify NeuralStore registration, forward pass activation counts, and genealogy linking for diverse atom types.