### PR TITLE
Refactor neural atom construction for factory consistency

### DIFF
--- a/src/atoms/chemistry/molecule_assembler.py
+++ b/src/atoms/chemistry/molecule_assembler.py
@@ -37,8 +37,12 @@ def make_composite_skill(
 
     class _CompositeSkill(NeuralAtom):  # type: ignore[misc]
         def __init__(self, meta: NeuralAtomMetadata, steps: list[CompositePlanStep]):  # type: ignore[override]
-            super().__init__(meta)
-            self.key = meta.name
+            super().__init__(
+                key=meta.name,
+                value={"steps": [s.atom_id for s in steps]},
+                metadata=meta,
+                birth_event=f"composite_skill:{meta.name}",
+            )
             self.steps = steps
 
         async def execute(self, input_data: Any | None = None) -> Any:

--- a/src/core/adaptive_neural_atom.py
+++ b/src/core/adaptive_neural_atom.py
@@ -65,8 +65,12 @@ class AdaptiveNeuralAtom(NeuralAtom):
     """
 
     def __init__(self, metadata: NeuralAtomMetadata):
-        super().__init__(metadata)
-        self.key = metadata.name  # Required for NeuralStore compatibility
+        super().__init__(
+            key=metadata.name,
+            value={},
+            metadata=metadata,
+            birth_event="adaptive_atom:init",
+        )
 
         # Adaptive learning components
         self.learning_metrics = LearningMetrics()

--- a/src/core/atom_tool.py
+++ b/src/core/atom_tool.py
@@ -311,16 +311,16 @@ def register_tool_atoms(store, owner_plugin: str = "atom_tools"):
     """
     import numpy as np
 
-    from src.core.neural_atom import create_memory_atom
+    from src.core.neural_atom import create_memory_chunk_atom
 
     for tool_key, tool_class in BUILT_IN_TOOLS.items():
         tool_instance = tool_class()
 
         # Create atom with tool data
-        atom = create_memory_atom(
+        atom = create_memory_chunk_atom(
             key=f"tool_{tool_key}",
             content=tool_instance.to_atom_value(),
-            hierarchy_path="tool",
+            hierarchy_path=["tools", owner_plugin],
             vector=np.random.rand(EMBEDDING_DIM).astype(
                 np.float32
             ),  # Would use real embedding

--- a/src/core/copilot_agent_mode.py
+++ b/src/core/copilot_agent_mode.py
@@ -61,7 +61,12 @@ class CopilotAgentAtom(NeuralAtom):
     """Neural Atom for Copilot agent reasoning and conversation analysis."""
 
     def __init__(self, metadata: NeuralAtomMetadata) -> None:
-        super().__init__(metadata)
+        super().__init__(
+            key=metadata.name,
+            value={"session_context": {}},
+            metadata=metadata,
+            birth_event="copilot_agent:init",
+        )
         self.conversation_history: list[dict[str, Any]] = []
         self.session_context: dict[str, Any] = {}
 

--- a/src/core/copilot_snippet_optimizer.py
+++ b/src/core/copilot_snippet_optimizer.py
@@ -132,7 +132,12 @@ class SnippetIntelligenceAtom(NeuralAtom):
     """Neural Atom for intelligent snippet selection and token optimization."""
 
     def __init__(self, metadata: NeuralAtomMetadata):
-        super().__init__(metadata)
+        super().__init__(
+            key=metadata.name,
+            value={},
+            metadata=metadata,
+            birth_event="snippet_intelligence:init",
+        )
         self.snippet_patterns = PYTHON_SNIPPET_PATTERNS
         self.usage_statistics = {}
         self.optimization_cache = {}

--- a/src/core/meta_learning_creator.py
+++ b/src/core/meta_learning_creator.py
@@ -125,8 +125,12 @@ class {class_name}(NeuralAtom):
     """
 
     def __init__(self, metadata: NeuralAtomMetadata, {additional_params}):
-        super().__init__(metadata)
-        self.key = metadata.name
+        super().__init__(
+            key=metadata.name,
+            value={},
+            metadata=metadata,
+            birth_event=f"tool_creation:{{metadata.name}}",
+        )
         {initialization}
 
     async def execute(self, input_data: Any) -> Any:

--- a/src/core/neural_atom.py
+++ b/src/core/neural_atom.py
@@ -7,7 +7,6 @@ import hashlib
 import logging
 import os
 import time
-from abc import ABC, abstractmethod
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -52,42 +51,131 @@ class NeuralAtomMetadata:
             self.created_at = time.time()
 
 
-class NeuralAtom(ABC):
-    """
-    Base class for all Neural Atoms with full cognitive capabilities.
+class NeuralAtom(Generic[T]):
+    """Concrete cognitive atom with genealogy and execution tracking."""
 
-    The unifying element of the architecture - semantically-rich, modular units
-    of intelligence containing executable logic, metadata, and semantic embeddings.
-    """
+    DEFAULT_VECTOR_DIM = 1024
 
-    def __init__(self, metadata: NeuralAtomMetadata):
-        self.metadata = metadata
+    def __init__(
+        self,
+        key: str,
+        value: T,
+        *,
+        vector: np.ndarray | None = None,
+        bias: float = 0.0,
+        parent_keys: list[str] | None = None,
+        birth_event: str | None = None,
+        lineage_metadata: dict[str, Any] | None = None,
+        metadata: NeuralAtomMetadata | None = None,
+    ) -> None:
+        if not key or not isinstance(key, str):
+            raise ValueError("NeuralAtom key must be a non-empty string.")
+
+        self.key = key
+        self.value = value
+        self.default_value = value
+
+        if vector is not None:
+            arr = np.asarray(vector, dtype=np.float32)
+            if arr.ndim != 1:
+                raise ValueError(
+                    "NeuralAtom vector must be one-dimensional for cognitive embedding."
+                )
+            self.vector = arr
+        else:
+            self.vector = np.zeros(self.DEFAULT_VECTOR_DIM, dtype=np.float32)
+
+        self.bias = float(bias)
+        self.active = True
+
+        self.parent_keys: list[str] = list(parent_keys) if parent_keys else []
+        self.children_keys: list[str] = []
+        self.birth_event = birth_event
+        self.lineage_metadata: dict[str, Any] = dict(lineage_metadata or {})
+
+        self.depth = len(self.parent_keys)
+        self.signature = self._generate_darwin_godel_signature()
+        self.creation_time = datetime.now(UTC)
+        self.last_activation_time = datetime.now(UTC)
+        self.activation_count = 0
+        self.fitness_score = 0.0
+
+        self.activation_threshold = 0.5
+        self.decay_rate = 0.95
+        self.refractory_period = 0.1
+        self.last_spike_time = 0.0
+
+        self.metadata = metadata or NeuralAtomMetadata(
+            name=key,
+            description="",
+            capabilities=[],
+        )
         self._execution_history: list[dict[str, Any]] = []
         self._semantic_embedding: list[float] | None = None
 
-    @abstractmethod
-    async def execute(self, input_data: Any) -> Any:
-        """Execute the Neural Atom's core functionality."""
+    async def execute(self, input_data: Any = None) -> Any:
+        """Default execution returns stored value with optional input echo."""
 
-    @abstractmethod
+        return {
+            "key": self.key,
+            "value": self.value,
+            "input": input_data,
+        }
+
     def get_embedding(self) -> list[float]:
-        """Return semantic embedding for similarity search."""
+        """Return (and cache) the semantic embedding for this atom."""
 
-    @abstractmethod
+        if self._semantic_embedding is None:
+            if isinstance(self.vector, np.ndarray):
+                self._semantic_embedding = self.vector.astype(np.float32).tolist()
+            else:
+                self._semantic_embedding = list(self.vector)
+        return self._semantic_embedding
+
     def can_handle(self, task_description: str) -> float:
-        """Return confidence score (0-1) for handling this task."""
+        """Heuristic confidence based on key and value overlap."""
+
+        if not task_description:
+            return 0.0
+
+        description = task_description.lower()
+        score = 0.0
+
+        if self.key.lower() in description:
+            score += 0.5
+
+        value_tokens: set[str] = set()
+        if isinstance(self.value, str):
+            value_tokens = set(self.value.lower().split())
+        elif isinstance(self.value, dict):
+            combined = " ".join(str(v).lower() for v in self.value.values())
+            value_tokens = set(combined.split())
+
+        if value_tokens:
+            overlap = value_tokens & set(description.split())
+            if overlap:
+                score += min(0.5, len(overlap) * 0.1)
+
+        return min(score, 1.0)
 
     async def safe_execute(self, input_data: Any) -> dict[str, Any]:
-        """Execute with comprehensive monitoring and performance tracking."""
+        """Execute with monitoring and update performance metrics."""
+
         start_time = time.time()
 
         try:
             result = await self.execute(input_data)
             execution_time = time.time() - start_time
-            success = True
+            self._update_performance_metrics(execution_time, True)
 
-            # Update performance metrics
-            self._update_performance_metrics(execution_time, success)
+            self._execution_history.append(
+                {
+                    "input": input_data,
+                    "result": result,
+                    "success": True,
+                    "execution_time": execution_time,
+                }
+            )
 
             return {
                 "result": result,
@@ -96,131 +184,55 @@ class NeuralAtom(ABC):
                 "metadata": self.metadata,
             }
 
-        except Exception as e:
+        except Exception as exc:  # pragma: no cover - defensive branch
             execution_time = time.time() - start_time
             self._update_performance_metrics(execution_time, False)
+
+            self._execution_history.append(
+                {
+                    "input": input_data,
+                    "result": None,
+                    "success": False,
+                    "error": str(exc),
+                    "execution_time": execution_time,
+                }
+            )
 
             return {
                 "result": None,
                 "success": False,
-                "error": str(e),
+                "error": str(exc),
                 "execution_time": execution_time,
                 "metadata": self.metadata,
             }
 
-    def _update_performance_metrics(self, execution_time: float, success: bool):
-        """Update metadata with performance information."""
-        # Update usage count
+    def _update_performance_metrics(self, execution_time: float, success: bool) -> None:
+        """Update metadata statistics based on execution outcome."""
+
         self.metadata.usage_count += 1
 
-        # Update average execution time using exponential moving average
         if self.metadata.avg_execution_time == 0.0:
             self.metadata.avg_execution_time = execution_time
         else:
-            alpha = 0.1  # Learning rate for exponential moving average
+            alpha = 0.1
             self.metadata.avg_execution_time = (
                 alpha * execution_time + (1 - alpha) * self.metadata.avg_execution_time
             )
 
-        # Update success rate using exponential moving average
         success_value = 1.0 if success else 0.0
-
         if self.metadata.usage_count == 1:
             self.metadata.success_rate = success_value
         else:
-            alpha = 0.1  # Learning rate for exponential moving average
+            alpha = 0.1
             self.metadata.success_rate = (
                 alpha * success_value + (1 - alpha) * self.metadata.success_rate
             )
 
     @property
     def average_latency_ms(self) -> float:
-        """Return average execution latency in milliseconds."""
+        """Average execution latency in milliseconds."""
+
         return self.metadata.avg_execution_time * 1000.0
-
-
-# Legacy Neural Atom for backwards compatibility
-class LegacyNeuralAtom(Generic[T]):
-    """
-    A single cognitive neuron, the fundamental unit of thought and memory.
-
-    Each atom is a neuro-symbolic entity, holding:
-    - key (str): A unique, global address for this thought/memory.
-    - value (T): The symbolic, human-readable payload (e.g., a piece of text,
-      a tool's state, a plan step).
-    - vector (np.ndarray): A 1024-D semantic embedding representing the atom's
-      meaning and its activation state in the cognitive graph.
-    - bias (float): A learnable activation bias, allowing the neuron to be
-      more or less easily activated.
-    - Genealogy Fields: Attributes for tracking the atom's origin, parents,
-      and children, forming the Darwin-Gödel evolutionary tree.
-    - Neural Dynamics: Advanced features for realistic neural behavior.
-    """
-
-    """
-    A single cognitive neuron, the fundamental unit of thought and memory.
-
-    Each atom is a neuro-symbolic entity, holding:
-    - key (str): A unique, global address for this thought/memory.
-    - value (T): The symbolic, human-readable payload (e.g., a piece of text,
-      a tool's state, a plan step).
-    - vector (np.ndarray): A 1024-D semantic embedding representing the atom's
-      meaning and its activation state in the cognitive graph.
-    - bias (float): A learnable activation bias, allowing the neuron to be
-      more or less easily activated.
-    - Genealogy Fields: Attributes for tracking the atom's origin, parents,
-      and children, forming the Darwin-Gödel evolutionary tree.
-    - Neural Dynamics: Advanced features for realistic neural behavior.
-    """
-
-    def __init__(
-        self,
-        key: str,
-        default_value: T,
-        vector: np.ndarray | None = None,
-        bias: float = 0.0,
-        parent_keys: list[str] | None = None,
-        birth_event: str | None = None,
-        lineage_metadata: dict[str, Any] | None = None,
-    ):
-        if not key or not isinstance(key, str):
-            raise ValueError("NeuralAtom key must be a non-empty string.")
-
-        self.key = key
-        self.value = default_value
-
-        # Initialize 1024-D semantic vector
-        if vector is not None:
-            if vector.shape != (1024,):
-                raise ValueError(
-                    f"Vector for atom '{key}' must be 1024-D, but got shape {vector.shape}."
-                )
-            self.vector = vector.astype(np.float32)
-        else:
-            self.vector = np.zeros(1024, dtype=np.float32)
-
-        self.bias = float(bias)
-        self.active = True  # Whether this atom is currently active
-
-        # Genealogy bookkeeping for the Darwin-Gödel model
-        self.parent_keys: list[str] = parent_keys or []
-        self.children_keys: list[str] = []
-        self.birth_event = birth_event
-        self.lineage_metadata: dict[str, Any] = lineage_metadata or {}
-
-        # Enhanced genealogy features
-        self.depth = len(self.parent_keys)  # Genealogical depth
-        self.signature = self._generate_darwin_godel_signature()
-        self.creation_time = datetime.now(UTC)
-        self.last_activation_time = datetime.now(UTC)
-        self.activation_count = 0
-        self.fitness_score = 0.0  # For evolutionary selection
-
-        # Neural dynamics
-        self.activation_threshold = 0.5
-        self.decay_rate = 0.95
-        self.refractory_period = 0.1  # seconds
-        self.last_spike_time = 0.0
 
     def _generate_darwin_godel_signature(self) -> str:
         """Generate unique Darwin-Gödel signature for genealogy tracking."""
@@ -281,7 +293,7 @@ class LegacyNeuralAtom(Generic[T]):
         }
 
     def __repr__(self) -> str:
-        return f"NeuralAtom(key='{self.key}', value={self.value})"
+        return f"NeuralAtom(key='{self.key}', value={self.value!r})"
 
 
 class NeuralStore:
@@ -887,9 +899,16 @@ def create_skill_atom(
         "metadata": metadata,
     }
 
+    atom_metadata = NeuralAtomMetadata(
+        name=f"skill:{skill_name}",
+        description=skill_description,
+        capabilities=list(metadata.get("capabilities", [])),
+        tags=set(metadata.get("tags", [])),
+    )
+
     return NeuralAtom(
-        key=f"skill:{skill_name}",
-        default_value=skill_data,
+        key=atom_metadata.name,
+        value=skill_data,
         vector=embedding_vector,
         parent_keys=[atom.key for atom in parent_atoms] if parent_atoms else [],
         birth_event=f"skill_creation:{skill_name}",
@@ -900,6 +919,7 @@ def create_skill_atom(
             "complexity_score": metadata.get("complexity", 0.0),
             "generation": metadata.get("generation", 0),
         },
+        metadata=atom_metadata,
     )
 
 
@@ -925,9 +945,16 @@ def create_memory_atom(
         "last_accessed": datetime.now(UTC).isoformat(),
     }
 
+    atom_metadata = NeuralAtomMetadata(
+        name=f"memory:{memory_type}:{memory_key}",
+        description=f"{memory_type} memory",
+        capabilities=[memory_type],
+        tags={memory_type, "memory"},
+    )
+
     return NeuralAtom(
-        key=f"memory:{memory_type}:{memory_key}",
-        default_value=memory_data,
+        key=atom_metadata.name,
+        value=memory_data,
         vector=embedding_vector,
         parent_keys=[atom.key for atom in parent_atoms] if parent_atoms else [],
         birth_event=f"memory_creation:{memory_type}",
@@ -937,6 +964,7 @@ def create_memory_atom(
             "creation_method": "direct_storage",
             "content_hash": str(hash(str(content)))[:16] if content else "",
         },
+        metadata=atom_metadata,
     )
 
 
@@ -963,9 +991,16 @@ def create_goal_atom(
         "completion_criteria": [],
     }
 
+    atom_metadata = NeuralAtomMetadata(
+        name=f"goal:{goal_id}",
+        description=goal_description,
+        capabilities=["goal_management"],
+        tags={"goal", "objective"},
+    )
+
     return NeuralAtom(
-        key=f"goal:{goal_id}",
-        default_value=goal_data,
+        key=atom_metadata.name,
+        value=goal_data,
         vector=embedding_vector,
         parent_keys=[atom.key for atom in parent_atoms] if parent_atoms else [],
         birth_event=f"goal_creation:{goal_id}",
@@ -975,46 +1010,51 @@ def create_goal_atom(
             "creation_method": "direct_assignment",
             "expected_difficulty": "unknown",
         },
+        metadata=atom_metadata,
     )
 
 
 # --- Helper Functions ---
 
 
-def create_memory_atom(
+def create_memory_chunk_atom(
     key: str, content: dict[str, Any], hierarchy_path: list[str], vector: np.ndarray
 ) -> NeuralAtom:
-    """
-    Creates a NeuralAtom specifically for storing a memory chunk.
-    This standardizes the structure of memory atoms for easier testing and retrieval.
-    """
+    """Create a structured memory atom for hierarchical storage."""
+
+    metadata = NeuralAtomMetadata(
+        name=key,
+        description="structured memory chunk",
+        capabilities=["memory"],
+        tags={"memory", "chunk"},
+    )
+
     return NeuralAtom(
         key=key,
-        default_value={"content": content, "hierarchy_path": hierarchy_path},
+        value={"content": content, "hierarchy_path": hierarchy_path},
         vector=vector,
         birth_event="memory_creation",
+        metadata=metadata,
     )
 
 
-class TextualMemoryAtom(NeuralAtom):
-    """
-    A concrete NeuralAtom for storing and retrieving a piece of text.
-
-    This class solves the TypeError that occurs when trying to instantiate
-    the abstract NeuralAtom class directly for memory storage.
-    """
+class TextualMemoryAtom(NeuralAtom[str]):
+    """Concrete neural atom for textual memory content."""
 
     def __init__(
         self, metadata: NeuralAtomMetadata, content: str, embedding_client: Any = None
-    ):
-        # Call parent constructor with just metadata (the abstract NeuralAtom(ABC) expects only this)
-        super().__init__(metadata)
-        # Store additional properties specific to textual memories
+    ) -> None:
+        super().__init__(
+            key=metadata.name,
+            value=content,
+            birth_event="memory_creation:textual",
+            lineage_metadata={"memory_type": "textual"},
+            metadata=metadata,
+        )
         self.content = content
-        self.key = metadata.name  # Add key attribute for NeuralStore compatibility
         self._embedding_client = embedding_client
         self._semantic_embedding = None
-        # Generate embedding on creation if client available
+
         if self._embedding_client:
             self._semantic_embedding = self.get_embedding()
 

--- a/src/core/plan_executor_clean.py
+++ b/src/core/plan_executor_clean.py
@@ -263,7 +263,7 @@ class PlanExecutor:
                 return
 
             # Store result using NeuralStore register method
-            result_atom = NeuralAtom(key=f"result_{waiting_key}", default_value=result)
+            result_atom = NeuralAtom(key=f"result_{waiting_key}", value=result)
             self.store.register(result_atom)
 
             # Signal waiter
@@ -351,7 +351,7 @@ Focus on the key findings or outcomes, not the technical steps.
         """Persist plan for recovery."""
         plan_atom = NeuralAtom(
             key=plan_id,
-            default_value={
+            value={
                 "goal": goal,
                 "steps": [asdict(s) for s in plan],
                 "created_at": datetime.now().isoformat(),

--- a/src/plugins/creator_plugin_unified.py
+++ b/src/plugins/creator_plugin_unified.py
@@ -68,9 +68,12 @@ class {class_name}(NeuralAtom):
                 capabilities={capabilities},
                 version="1.0.0"
             )
-        super().__init__(metadata)
-        # RULE 3: System compatibility - add .key for NeuralStore
-        self.key = metadata.name
+        super().__init__(
+            key=metadata.name,
+            value={},
+            metadata=metadata,
+            birth_event=f"generated_atom:{{metadata.name}}",
+        )
 
     async def execute(self, input_data: Any) -> Any:
         """Execute the Neural Atom's core functionality."""
@@ -118,9 +121,12 @@ class {class_name}(NeuralAtom):
                 version="1.0.0",
                 tags={{"tool", "generated"}}
             )
-        super().__init__(metadata)
-        # RULE 3: System compatibility - add .key for NeuralStore
-        self.key = metadata.name
+        super().__init__(
+            key=metadata.name,
+            value={},
+            metadata=metadata,
+            birth_event=f"generated_tool:{{metadata.name}}",
+        )
 
     async def execute(self, input_data: Any) -> Any:
         """Execute the tool functionality."""

--- a/src/plugins/ladder_aog_plugin.py
+++ b/src/plugins/ladder_aog_plugin.py
@@ -996,7 +996,7 @@ task:
                 cost_estimate=1.0,
                 success_probability=0.8,
             )
-            atom = NeuralAtom(key=key, default_value=node, vector=vectors[i])
+            atom = NeuralAtom(key=key, value=node, vector=vectors[i])
             self.store.register(atom)
 
             # Build the parent map for reverse diagnosis

--- a/tests/core/test_neural_atom.py
+++ b/tests/core/test_neural_atom.py
@@ -1,15 +1,28 @@
 """Trimmed NeuralAtom tests (post-merge cleanup)."""
 
+import numpy as np
 import pytest
 
-from src.core.neural_atom import NeuralAtom, NeuralAtomMetadata, TextualMemoryAtom
+from src.core.neural_atom import (
+    NeuralAtom,
+    NeuralAtomMetadata,
+    TextualMemoryAtom,
+    create_goal_atom,
+    create_memory_atom,
+    create_memory_chunk_atom,
+    create_skill_atom,
+)
 
 
 class MockNeuralAtom(NeuralAtom):
     def __init__(self, metadata: NeuralAtomMetadata, test_value: str = "test"):
-        super().__init__(metadata)
+        super().__init__(
+            key=metadata.name,
+            value=test_value,
+            metadata=metadata,
+            birth_event="mock:test",
+        )
         self.test_value = test_value
-        self.key = metadata.name
 
     async def execute(self, input_data=None):  # pragma: no cover - trivial
         return {"result": self.test_value, "input": input_data}
@@ -47,6 +60,59 @@ def test_performance_tracking_updates():
     assert atom.metadata.usage_count == 2
     assert 0 < atom.metadata.success_rate < 1.0
     assert atom.metadata.avg_execution_time > 0
+
+
+def test_factory_skill_atom_instantiation():
+    atom = create_skill_atom(
+        skill_name="planner",
+        skill_code="def run(): return True",
+        skill_description="planning utility",
+        metadata={"capabilities": ["plan"]},
+    )
+
+    assert isinstance(atom, NeuralAtom)
+    assert atom.key == "skill:planner"
+    assert atom.value["type"] == "skill"
+    assert atom.metadata.name == "skill:planner"
+
+
+def test_factory_memory_atom_instantiation():
+    atom = create_memory_atom(
+        memory_key="session-1",
+        content={"note": "remember"},
+        memory_type="session",
+        confidence=0.9,
+    )
+
+    assert atom.key == "memory:session:session-1"
+    assert atom.lineage_metadata["memory_type"] == "session"
+    assert atom.value["content"]["note"] == "remember"
+
+
+def test_factory_goal_atom_instantiation():
+    atom = create_goal_atom(
+        goal_id="goal-123",
+        goal_description="Ship feature",
+        priority=0.75,
+    )
+
+    assert atom.key == "goal:goal-123"
+    assert atom.value["priority"] == 0.75
+    assert atom.lineage_metadata["goal_type"] == "primary"
+
+
+def test_factory_memory_chunk_atom_instantiation():
+    vector = np.zeros(8, dtype=np.float32)
+    atom = create_memory_chunk_atom(
+        key="memory:chunk:1",
+        content={"data": "value"},
+        hierarchy_path=["root", "child"],
+        vector=vector,
+    )
+
+    assert atom.key == "memory:chunk:1"
+    assert atom.value["content"]["data"] == "value"
+    assert atom.value["hierarchy_path"] == ["root", "child"]
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
## Summary
- replace the abstract/legacy neural atom split with a unified concrete implementation that accepts cognitive and genealogical fields
- update neural atom factory helpers and downstream atom subclasses/templates to call the new initializer
- add focused regression tests covering every factory helper to ensure instantiation succeeds

## What changed / Why
- the old abstract `NeuralAtom` rejected the arguments supplied by factory helpers, causing inconsistent construction paths. unifying the implementation resolves that mismatch and centralizes energy/lineage tracking
- dependent atoms, templates, and helper utilities now import the shared constructor path (or the renamed chunk helper) so they no longer rely on legacy defaults
- regression tests were added to lock in the expected factory behavior and guard against future signature drift

## Risks
- runtime components that construct atoms may depend on the previous initializer signature; thorough smoke tests are recommended in staging
- templated code generation relies on the updated string literals and could produce invalid snippets if additional escaping is required

## Test coverage
- new unit tests in `tests/core/test_neural_atom.py` cover each factory helper

## Verification
- `pytest tests/core/test_neural_atom.py -q` *(fails: environment pytest plugins incompatible with bundled pytest version — see ImportError for `FixtureDef` from `pytest`)*

## Runtime impact
- no additional latency or resource consumption is expected; initialization remains in-memory only

## Observability
- no changes to telemetry schemas or logging pathways

## Rollback
- revert commit `77082f82446a7bcabf3bc9dfadffa8f269b4c289`


------
https://chatgpt.com/codex/tasks/task_e_68e36b7897708328976a333817619840