### PR TITLE
Unify router format enforcement helper and add unicode regression test

### DIFF
--- a/src/reug_runtime/router.py
+++ b/src/reug_runtime/router.py
@@ -68,7 +68,6 @@ class Orchestrator:
         self.model = model
         self.correlation_id = correlation_id
         self._mcp_box_dir = Path(os.getenv("MCP_BOX_DIR", ".mcp_box"))
-        self._last_reasoning_result: tuple[str, list[dict[str, Any]]] = ("", [])
         self._last_reasoning_result: tuple[str, list[Any]] = ("", [])
         self._last_acting_result: list[dict[str, Any]] = []
 
@@ -149,7 +148,8 @@ class Orchestrator:
                             "owner": a.get("owner"),
                             "repo": a.get("repo"),
                             "path": a.get("path"),
-                        } | ({"ref": a.get("ref")} if a.get("ref") else {}),
+                        }
+                        | ({"ref": a.get("ref")} if a.get("ref") else {}),
                     )
                     return cast(dict[str, Any], result)
 
@@ -348,7 +348,9 @@ class Orchestrator:
                 )
             except Exception:
                 tool_args_obj = {}
-            tool_args: dict[str, Any] = tool_args_obj if isinstance(tool_args_obj, dict) else {}
+            tool_args: dict[str, Any] = (
+                tool_args_obj if isinstance(tool_args_obj, dict) else {}
+            )
             span_id = str(uuid.uuid4())
 
             ability_called_event = {
@@ -578,85 +580,58 @@ async def execute_turn(
                         }
                     )
 
-    def _enforce_output_contract_on_text(text: str) -> str:
-        """Optionally normalize text to reduce formatting issues.
+    def _enforce_output_contract_on_text(
+        text: str, *, enforce: bool | None = None
+    ) -> str:
+        """Normalize assistant text when formatting enforcement is enabled."""
 
-        - Replace common unicode operators with ASCII inside fenced blocks.
-        - Leave content unchanged when enforcement is disabled.
-        """
-        # Quick exit if nothing to do
-        if "```" not in text:
+        should_enforce = enforce
+        if should_enforce is None:
+            should_enforce = os.getenv("ALITA_FORMAT_ENFORCE", "false").lower() in {
+                "1",
+                "true",
+                "yes",
+                "on",
+            }
+
+        if not should_enforce or "```" not in text:
             return text
-        # Process fenced blocks only
-        parts: list[str] = []
-        lines = text.split("\n")
-        in_fence = False
-        buf: list[str] = []
 
-        def norm_line(s: str) -> str:
-            s = s.replace("×", " * ").replace("·", " * ")
-            s = s.replace("−", "-").replace("–", "-").replace("—", "-")
-            s = s.replace("“", '"').replace("”", '"').replace("’", "'")
-            return s
+        try:
+            parts: list[str] = []
+            lines = text.split("\n")
+            in_fence = False
+            buf: list[str] = []
 
-        for line in lines:
-            if line.startswith("```"):
+            def norm_line(s: str) -> str:
+                s = s.replace("×", " * ").replace("·", " * ")
+                s = s.replace("−", "-").replace("–", "-").replace("—", "-")
+                s = s.replace("“", '"').replace("”", '"').replace("’", "'")
+                return s
+
+            for line in lines:
+                if line.startswith("```"):
+                    if in_fence:
+                        parts.append("\n".join(buf))
+                        buf = []
+                        in_fence = False
+                        parts.append(line)
+                    else:
+                        in_fence = True
+                        parts.append(line)
+                    continue
                 if in_fence:
-                    # close fence: flush normalized buffer
-                    parts.append("\n".join(buf))
-                    buf = []
-                    in_fence = False
-                    parts.append(line)
+                    buf.append(norm_line(line))
                 else:
-                    in_fence = True
                     parts.append(line)
-                continue
-            if in_fence:
-                buf.append(norm_line(line))
-            else:
-                parts.append(line)
-        # If fence left open, append remaining
-        if buf:
-            parts.append("\n".join(buf))
-        return "\n".join(parts)
-
-    def _normalize_code_blocks(text: str) -> str:
-        if "```" not in text:
+            if buf:
+                parts.append("\n".join(buf))
+            return "\n".join(parts)
+        except Exception:
             return text
-        parts: list[str] = []
-        lines = text.split("\n")
-        in_fence = False
-        buf: list[str] = []
-
-        def norm_line(s: str) -> str:
-            s = s.replace("×", " * ").replace("·", " * ")
-            s = s.replace("−", "-").replace("–", "-").replace("—", "-")
-            s = s.replace("“", '"').replace("”", '"').replace("’", "'")
-            return s
-
-        for line in lines:
-            if line.startswith("```"):
-                if in_fence:
-                    parts.append("\n".join(buf))
-                    buf = []
-                    in_fence = False
-                    parts.append(line)
-                else:
-                    in_fence = True
-                    parts.append(line)
-                continue
-            if in_fence:
-                buf.append(norm_line(line))
-            else:
-                parts.append(line)
-        if buf:
-            parts.append("\n".join(buf))
-        return "\n".join(parts)
 
     content_out = llm_response_content or "Task complete."
-    if os.getenv("ALITA_FORMAT_ENFORCE", "false").lower() in {"1", "true", "yes", "on"}:
-        with contextlib.suppress(Exception):
-            content_out = _normalize_code_blocks(content_out)
+    content_out = _enforce_output_contract_on_text(content_out)
 
     final_answer = {
         "content": content_out,
@@ -799,11 +774,7 @@ async def chat_stream(request: Request) -> StreamingResponse | JSONResponse:
     except Exception:
         pass
     raw_body = await request.json()
-    body: dict[str, Any]
-    if isinstance(raw_body, dict):
-        body = raw_body
-    else:
-        body = {}
+    body: dict[str, Any] = raw_body if isinstance(raw_body, dict) else {}
     user_msg = body.get("message", "")
     session_id = body.get("session_id", "default")
 

--- a/tests/runtime/test_router_output_formatting.py
+++ b/tests/runtime/test_router_output_formatting.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from typing import Any
+
+import pytest
+from reug_runtime.router import execute_turn
+
+from tests.runtime.fakes import FakeAbilityRegistry, FakeEventBus, FakeKG
+
+
+class _UnicodeFormattingLLM:
+    """LLM stub that emits a final answer with problematic punctuation."""
+
+    def __init__(self) -> None:
+        self._payload = (
+            "Here is code:\n"
+            "```python\n"
+            "result = 5 × 3 − 2\n"
+            "quote = '“smart” quotes'\n"
+            'name = "O’Connor"\n'
+            "```\n"
+            "Outside — should stay fancy."
+        )
+
+    async def stream_chat(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        tools: list[dict[str, Any]] | None = None,
+        timeout: float | None = None,
+    ) -> AsyncGenerator[dict[str, str], None]:
+        del messages, tools, timeout
+        yield {"content": self._payload}
+
+
+@pytest.mark.asyncio
+async def test_execute_turn_normalizes_code_blocks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ALITA_FORMAT_ENFORCE", "true")
+
+    bus = FakeEventBus()
+    reg = FakeAbilityRegistry()
+    kg = FakeKG()
+    model = _UnicodeFormattingLLM()
+
+    events = [
+        event async for event in execute_turn("hi", "session", bus, reg, kg, model)
+    ]
+
+    final_event = events[-1]
+    assert final_event["type"] == "TaskSucceeded"
+
+    expected = (
+        "Here is code:\n"
+        "```python\n"
+        "result = 5  *  3 - 2\n"
+        "quote = '\"smart\" quotes'\n"
+        'name = "O\'Connor"\n'
+        "```\n"
+        "Outside — should stay fancy."
+    )
+
+    assert final_event["data"]["content"] == expected
+    # Ensure punctuation outside fences is untouched
+    assert "Outside — should stay fancy." in final_event["data"]["content"]


### PR DESCRIPTION
## Summary
- unify the router formatting enforcement into `_enforce_output_contract_on_text` so the environment toggle is handled in one place
- streamline minor router initialization/JSON parsing details touched by the refactor
- add a regression test that proves Unicode punctuation inside fenced code blocks is normalized when the `ALITA_FORMAT_ENFORCE` flag is enabled

## What changed / Why
- removed the duplicated `_normalize_code_blocks` helper and pushed the `ALITA_FORMAT_ENFORCE` toggle logic inside `_enforce_output_contract_on_text` to keep enforcement behavior centralized and easier to extend
- cleaned up incidental style warnings that the formatter surfaced while touching the file to keep CI noise down
- created `tests/runtime/test_router_output_formatting.py` to lock in the expected normalization of typographic punctuation inside code fences so future changes do not regress the toggle behavior

## Risks
- Low: behavior only changes when `ALITA_FORMAT_ENFORCE` is active, but there is some risk of subtle differences in normalization if the helper logic regresses

## Test coverage
- Added a runtime-level regression test that exercises the router with problematic Unicode characters and asserts the normalized output

## Verification
- `pre-commit run --files src/reug_runtime/router.py tests/runtime/test_router_output_formatting.py` *(fails: repository mypy configuration cannot resolve FastAPI/pytest imports in this environment)*
- `pytest -q tests/runtime` *(fails: pytest/pytest-asyncio plugin incompatibility in the current environment)*

## Runtime impact
- None; the helper adds only an environment guard before performing the existing normalization work

## Observability
- No telemetry schemas or event shapes changed

## Rollback
- Revert commit `[reug_runtime] unify format enforcement helper`


------
https://chatgpt.com/codex/tasks/task_e_68e4a248ed0483288d10e064351bd408

## Summary by Sourcery

Centralize text formatting enforcement in the router, remove duplicate normalization logic, streamline related initialization and parsing code, and add a regression test to verify Unicode punctuation normalization in fenced code blocks

Enhancements:
- Unify output formatting enforcement into a single helper `_enforce_output_contract_on_text` and remove the duplicate `_normalize_code_blocks`
- Simplify router initialization, JSON parsing, and related conditional assignments
- Clean up incidental style warnings surfaced by the refactor

Tests:
- Add a runtime regression test to ensure Unicode punctuation is normalized inside fenced code blocks when the enforcement flag is enabled