### PR TITLE
tests: dedupe router smoke test

### DIFF
--- a/tests/runtime/test_router_smoke.py
+++ b/tests/runtime/test_router_smoke.py
@@ -1,3 +1,4 @@
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -16,50 +17,23 @@ def _make_app() -> FastAPI:
     return app
 
 
-def test_streaming_single_turn_smoke() -> None:
+@pytest.mark.parametrize("request_path", ["/v1/chat/stream"])
+def test_streaming_single_turn_smoke(request_path: str) -> None:
     app = _make_app()
     client = TestClient(app)
+
     resp = client.post(
-        prefix_path("/v1/chat/stream"), json={"message": "hello", "session_id": "s1"}
+        prefix_path(request_path), json={"message": "hello", "session_id": "s1"}
     )
+
     assert resp.status_code == 200
+
     text = resp.text
     # sanity: router streamed tokens and produced final answer
     assert "Thinking..." in text
     assert "<final_answer>" in text
     assert "done: hi" in text
-    # events emitted as the loop progressed
-    evts = app.state.event_bus.events
-    kinds = {e["type"] for e in evts}
-    assert "TaskStarted" in kinds
-    assert "AbilityCalled" in kinds
-    assert "AbilitySucceeded" in kinds
-    assert "TaskSucceeded" in kinds
 
-
-from fastapi import FastAPI
-
-
-def _make_app() -> FastAPI:
-    app = FastAPI()
-    app.include_router(router)
-    app.state.event_bus = FakeEventBus()
-    app.state.ability_registry = FakeAbilityRegistry()
-    app.state.kg = FakeKG()
-    app.state.llm_model = FakeLLM()
-    return app
-
-
-def test_streaming_single_turn_smoke() -> None:
-    app = _make_app()
-    client = TestClient(app)
-    resp = client.post("/v1/chat/stream", json={"message": "hello", "session_id": "s1"})
-    assert resp.status_code == 200
-    text = resp.text
-    # sanity: router streamed tokens and produced final answer
-    assert "Thinking..." in text
-    assert "<final_answer>" in text
-    assert "done: hi" in text
     # events emitted as the loop progressed
     evts = app.state.event_bus.events
     kinds = {e["type"] for e in evts}


### PR DESCRIPTION
Summary:
- collapse duplicate router smoke test helper and case

What changed / Why:
- ensure single _make_app helper used by runtime router smoke coverage
- parameterize streaming smoke test on request path for future variants while consistently applying prefix_path

Risks:
- low; touches isolated test module only

Test coverage:
- existing streaming smoke test retained and parameterized

Verification:
- pytest -q tests/runtime/test_router_smoke.py (fails: pytest plugin import error in environment)

Runtime impact:
- none; test-only change

Observability:
- no telemetry schema adjustments required

Rollback:
- revert tests/runtime/test_router_smoke.py to prior revision

------
https://chatgpt.com/codex/tasks/task_e_68e4a259c594832888c61cf1d740763c