### PR TITLE
Add status board snapshot to refactoring planner

### DIFF
--- a/src/planning/refactoring_task_force.py
+++ b/src/planning/refactoring_task_force.py
@@ -350,6 +350,87 @@ class RefactoringTaskForce:
             "reward": reward,
         }
 
+    def generate_status_board(self) -> dict[str, object]:
+        """Provide a snapshot of member capacity and objective task states."""
+
+        objective_summaries: list[dict[str, object]] = []
+        for objective in self._objective_order:
+            tasks = [
+                self._tasks[task_id]
+                for task_id in sorted(self._tasks)
+                if self._tasks[task_id].objective_id == objective.objective_id
+            ]
+            state_buckets: dict[str, list[str]] = {
+                state.value: [] for state in RefactoringTaskState
+            }
+            for task in tasks:
+                state_buckets[task.state.value].append(task.task_id)
+
+            state_counts = {
+                state: len(task_ids) for state, task_ids in state_buckets.items()
+            }
+            average_progress = (
+                round(sum(task.progress for task in tasks) / len(tasks), 4)
+                if tasks
+                else 0.0
+            )
+
+            objective_summaries.append(
+                {
+                    "objective_id": objective.objective_id,
+                    "description": objective.description,
+                    "progress": average_progress,
+                    "states": state_counts,
+                    "active": {
+                        "ready": list(state_buckets[RefactoringTaskState.READY.value]),
+                        "in_progress": list(
+                            state_buckets[RefactoringTaskState.IN_PROGRESS.value]
+                        ),
+                        "blocked": list(
+                            state_buckets[RefactoringTaskState.BLOCKED.value]
+                        ),
+                    },
+                }
+            )
+
+        member_summaries: list[dict[str, object]] = []
+        for member in sorted(self._members.values(), key=lambda entry: entry.name):
+            assignments = [
+                {
+                    "task_id": task.task_id,
+                    "objective_id": task.objective_id,
+                    "stage": task.stage.value,
+                    "state": task.state.value,
+                    "progress": round(task.progress, 4),
+                }
+                for task in self._tasks.values()
+                if task.assigned_to == member.name
+            ]
+            assignments.sort(key=lambda record: record["task_id"])
+
+            member_summaries.append(
+                {
+                    "name": member.name,
+                    "specialty": member.specialty.value,
+                    "capacity": member.capacity,
+                    "allocation": round(member.allocation, 4),
+                    "available_capacity": round(member.available_capacity(), 4),
+                    "assignments": assignments,
+                }
+            )
+
+        ready_next = sorted(
+            task.task_id
+            for task in self._tasks.values()
+            if task.state == RefactoringTaskState.READY
+        )
+
+        return {
+            "objectives": objective_summaries,
+            "members": member_summaries,
+            "ready_next": ready_next,
+        }
+
 
 __all__ = [
     "RefactoringFocus",

--- a/tests/planning/test_refactoring_task_force.py
+++ b/tests/planning/test_refactoring_task_force.py
@@ -116,3 +116,42 @@ def test_progress_updates_require_valid_range():
 
     with pytest.raises(ValueError):
         force.update_task_state(analysis_task.task_id, progress=1.2)
+
+
+def test_status_board_tracks_assignments_and_states():
+    force = build_sample_force()
+
+    board = force.generate_status_board()
+    stability_summary = next(
+        entry for entry in board["objectives"] if entry["objective_id"] == "runtime-stability"
+    )
+    assert stability_summary["states"][RefactoringTaskState.READY.value] == 3
+    assert stability_summary["states"][RefactoringTaskState.BLOCKED.value] == 1
+    assert stability_summary["progress"] == pytest.approx(0.0)
+    assert "runtime-stability:validation" in board["ready_next"]
+
+    force.update_task_state("runtime-stability:analysis", progress=0.5)
+    force.update_task_state(
+        "runtime-stability:implementation", state=RefactoringTaskState.IN_PROGRESS
+    )
+
+    updated_board = force.generate_status_board()
+    stability_summary = next(
+        entry
+        for entry in updated_board["objectives"]
+        if entry["objective_id"] == "runtime-stability"
+    )
+    assert stability_summary["states"][RefactoringTaskState.IN_PROGRESS.value] == 2
+    assert stability_summary["progress"] > 0
+    assert "runtime-stability:analysis" in stability_summary["active"]["in_progress"]
+
+    rhea_summary = next(
+        member for member in updated_board["members"] if member["name"] == "Rhea"
+    )
+    assert any(
+        assignment["task_id"] == "runtime-stability:analysis"
+        for assignment in rhea_summary["assignments"]
+    )
+    assert rhea_summary["available_capacity"] == pytest.approx(
+        rhea_summary["capacity"] - rhea_summary["allocation"]
+    )


### PR DESCRIPTION
## Summary
- add a `generate_status_board` helper so the refactoring planner can snapshot objective states, ready work, and member capacity in one payload
- extend the unit tests for `RefactoringTaskForce` to cover the new status board semantics and progression updates

## What changed / Why
- we need a quick way to continue orchestration once execution starts; the new helper supplies a structured view of in-progress/blocked tasks and staffing so we can react to partial completion signals without manual inspection
- tests assert the board tracks state transitions, member assignments, and capacity math to guard against regressions

## Risks
- low: the method only reads existing planner state and returns derived metadata, no mutations

## Test coverage
- `tests/planning/test_refactoring_task_force.py::test_status_board_tracks_assignments_and_states`

## Verification
- `pre-commit run --all-files` *(fails: command not found in container)*
- `pytest -q tests/runtime` *(fails: missing optional deps like fastapi/pydantic/httpx/mcp)*
- `pytest -q tests/planning/test_refactoring_task_force.py`

## Runtime impact
- none; planner-only reporting change

## Observability
- status board output now exposes ready/in-progress/blocked queues per objective plus per-member assignments for downstream dashboards

## Rollback
- revert commit 47db31121b0b3537bb8e9bbc717797d7a5ed3ddb


------
https://chatgpt.com/codex/tasks/task_e_68e588a49eb4832880a574db97592c19