### PR TITLE
feat: add loop alignment telemetry

### DIFF
--- a/src/reug_runtime/router.py
+++ b/src/reug_runtime/router.py
@@ -434,6 +434,11 @@ async def execute_turn(
         observability pipelines.
     """
     correlation_id = f"{session_id}-{int(time.time()*1000)}"
+    llm_token_chars = 0
+    ability_called = 0
+    ability_succeeded = 0
+    ability_failed = 0
+    tools_seen: list[str] = []
 
     # Optional message optimization/amplification
     if SETTINGS.message_optimizer_enabled:
@@ -539,6 +544,10 @@ async def execute_turn(
 
         # Run reasoning step and get results
         async for event in orchestrator._reasoning_step(messages, tool_schemas):
+            if event.get("type") == "LLMChunk":
+                text = event.get("data", {}).get("text", "")
+                if isinstance(text, str):
+                    llm_token_chars += len(text)
             yield event
         llm_response_content, tool_calls_raw = orchestrator._last_reasoning_result
         tool_calls: list[Any] = list(tool_calls_raw)
@@ -559,6 +568,16 @@ async def execute_turn(
 
         # Run acting step and get results
         async for event in orchestrator._acting_step(tool_calls):
+            etype = event.get("type")
+            if etype == "AbilityCalled":
+                ability_called += 1
+                tool_name = event.get("tool")
+                if isinstance(tool_name, str):
+                    tools_seen.append(tool_name)
+            elif etype == "AbilitySucceeded":
+                ability_succeeded += 1
+            elif etype == "AbilityFailed":
+                ability_failed += 1
             yield event
         tool_messages = orchestrator._last_acting_result
         messages.extend(tool_messages)
@@ -663,11 +682,19 @@ async def execute_turn(
         "citations": [],
     }
 
+    created_atom_ids: list[str] = []
+    pending_bonds: list[tuple[str, str, str]] = []
+    bond_previews: list[dict[str, str]] = []
+    final_atom_id: str | None = None
+
     with contextlib.suppress(Exception):
         atom_fn = getattr(kg, "create_atom", None)
         if callable(atom_fn):
             final_atom = await atom_fn("final_answer", final_answer)
             atom_id = final_atom.get("id") if isinstance(final_atom, dict) else None
+            if isinstance(atom_id, str):
+                final_atom_id = atom_id
+                created_atom_ids.append(atom_id)
             await event_bus.emit(
                 {
                     "type": "KnowledgeAtomCreated",
@@ -677,17 +704,62 @@ async def execute_turn(
                     "atom_type": "final_answer",
                 }
             )
-            if atom_id and kg_goal_id and hasattr(kg, "create_bond"):
+            if atom_id and kg_goal_id:
+                cb_fn = getattr(kg, "create_bond", None)
+                if callable(cb_fn):
+                    pending_bonds.append(("ANSWERED", kg_goal_id, atom_id))
+                    bond_previews.append(
+                        {
+                            "type": "ANSWERED",
+                            "source": kg_goal_id,
+                            "target": atom_id,
+                        }
+                    )
+
+    atoms_for_alignment: list[str] = []
+    if isinstance(kg_goal_id, str):
+        atoms_for_alignment.append(kg_goal_id)
+    atoms_for_alignment.extend(created_atom_ids)
+    bonds_for_alignment = bond_previews
+    token_measure = max(len(content_out), llm_token_chars)
+    energy_signal = max(
+        0.0,
+        round(0.1 * token_measure + ability_succeeded - ability_failed, 4),
+    )
+    todo_count = max(0, ability_called - ability_succeeded - ability_failed)
+    bandit_ready = max(0, ability_succeeded)
+    reward_payload = {
+        "success": 1.0 if final_atom_id else 0.0,
+        "tools": sorted({t for t in tools_seen if isinstance(t, str)}),
+    }
+    loop_alignment_event = {
+        "type": "LoopAlignmentTelemetry",
+        "correlation_id": correlation_id,
+        "session_id": session_id,
+        "atoms": atoms_for_alignment,
+        "bonds": bonds_for_alignment,
+        "energy": energy_signal,
+        "todo": todo_count,
+        "bandit": bandit_ready,
+        "reward": reward_payload,
+    }
+    await event_bus.emit(loop_alignment_event)
+    yield loop_alignment_event
+
+    if pending_bonds and kg is not None:
+        cb_fn = getattr(kg, "create_bond", None)
+        if callable(cb_fn):
+            for bond_type, source_atom_id, target_atom_id in pending_bonds:
                 with contextlib.suppress(Exception):
-                    await kg.create_bond("ANSWERED", kg_goal_id, atom_id)
+                    await cb_fn(bond_type, source_atom_id, target_atom_id)
                     await event_bus.emit(
                         {
                             "type": "KnowledgeBondCreated",
                             "correlation_id": correlation_id,
                             "session_id": session_id,
-                            "bond_type": "ANSWERED",
-                            "source_atom_id": kg_goal_id,
-                            "target_atom_id": atom_id,
+                            "bond_type": bond_type,
+                            "source_atom_id": source_atom_id,
+                            "target_atom_id": target_atom_id,
                         }
                     )
 

--- a/tests/runtime/test_router_loop_alignment.py
+++ b/tests/runtime/test_router_loop_alignment.py
@@ -1,0 +1,71 @@
+import json
+
+import pytest
+
+from src.reug_runtime.router import execute_turn, sse_transformer
+from tests.runtime.fakes import FakeAbilityRegistry, FakeEventBus, FakeKG, FakeLLM
+
+
+@pytest.mark.asyncio
+async def test_execute_turn_emits_loop_alignment_event() -> None:
+    bus = FakeEventBus()
+    registry = FakeAbilityRegistry()
+    kg = FakeKG()
+    model = FakeLLM()
+
+    events: list[dict[str, object]] = []
+    async for event in execute_turn("loop", "loop-session", bus, registry, kg, model):
+        events.append(event)
+
+    loop_events = [evt for evt in events if evt.get("type") == "LoopAlignmentTelemetry"]
+    assert loop_events, "expected loop alignment telemetry event"
+
+    telemetry = loop_events[0]
+    assert telemetry["atoms"], "atoms should include goal/final identifiers"
+    assert telemetry["bonds"], "bonds should preview pending graph connections"
+    assert telemetry["bonds"][0]["type"] == "ANSWERED"
+    assert telemetry["energy"] > 0
+    assert telemetry["todo"] == 0
+    assert telemetry["bandit"] >= 1
+    reward = telemetry["reward"]
+    assert isinstance(reward, dict) and reward.get("success") == 1.0
+
+    event_types = [evt["type"] for evt in bus.events]
+    assert "LoopAlignmentTelemetry" in event_types
+    assert "KnowledgeBondCreated" in event_types
+    assert event_types.index("LoopAlignmentTelemetry") < event_types.index("KnowledgeBondCreated")
+
+
+@pytest.mark.asyncio
+async def test_sse_stream_includes_loop_alignment_frame() -> None:
+    bus = FakeEventBus()
+    registry = FakeAbilityRegistry()
+    kg = FakeKG()
+    model = FakeLLM()
+
+    sse_chunks: list[str] = []
+    async for chunk in sse_transformer(
+        execute_turn("loop", "sse-session", bus, registry, kg, model)
+    ):
+        sse_chunks.append(chunk)
+
+    payload = "".join(sse_chunks)
+    frames = [frame for frame in payload.split("\n\n") if frame.strip()]
+    telemetry_frames: list[dict[str, object]] = []
+    for frame in frames:
+        data_line = next((line for line in frame.splitlines() if line.startswith("data: ")), None)
+        if not data_line:
+            continue
+        try:
+            parsed = json.loads(data_line[len("data: "):])
+        except json.JSONDecodeError:
+            continue
+        if isinstance(parsed, dict) and parsed.get("type") == "LoopAlignmentTelemetry":
+            telemetry_frames.append(parsed)
+
+    assert telemetry_frames, "Loop alignment telemetry frame missing from SSE stream"
+    telemetry = telemetry_frames[0]
+    assert telemetry["atoms"], "SSE telemetry should echo atoms"
+    assert telemetry["energy"] > 0
+    assert telemetry["bandit"] >= 1
+    assert telemetry["todo"] == 0


### PR DESCRIPTION
Summary:
- extend the REUG runtime router to synthesize loop-alignment telemetry after tool and answer phases settle
- add streaming runtime coverage that asserts the telemetry frame appears on the SSE transformer output

What changed / Why:
- track reasoning and acting flow metrics so closed-loop telemetry (atoms, bonds, energy, todo, bandit, reward) can be emitted once the final answer is prepared
- defer bond creation until after the telemetry frame is published so knowledge-graph IDs participate in energy propagation before linking
- add regression tests to ensure the execute_turn generator and SSE transformer surface the loop-alignment frame with the expected shape

Risks:
- incorrect telemetry computation could skew downstream analytics or omit bonds if goal/answer IDs are missing

Test coverage:
- added tests/runtime/test_router_loop_alignment.py to stream a synthetic session through execute_turn and sse_transformer and assert the new telemetry payloads

Verification:
- `pre-commit run --all-files` *(fails: repository contains existing lint/format violations outside the touched files)*
- `pytest -q tests/runtime` *(fails: pytest-asyncio plugin import error due to FixtureDef removal in upstream pytest)*

Runtime impact:
- minimal additional processing after each turn (simple counters and one extra emitted event)

Observability:
- new LoopAlignmentTelemetry event surfaces atoms, bonds, energy, todo count, bandit-ready counts, and reward for downstream consumers

Rollback:
- revert this commit to remove the telemetry synthesis and associated tests


------
https://chatgpt.com/codex/tasks/task_e_68e58ee6d8d883289f2a042c8698905f