### PR TITLE
Fix unified intelligence async orchestration

### DIFF
--- a/src/unified_intelligence/__init__.py
+++ b/src/unified_intelligence/__init__.py
@@ -41,7 +41,9 @@ class UnifiedIntelligenceEngine:
         enhanced = await engine.enhance_interaction("Create a new user auth feature")
     """
 
-    def __init__(self, workspace_root: str = None, mangle_executable: str = "mangle"):
+    def __init__(
+        self, workspace_root: str | None = None, mangle_executable: str = "mangle"
+    ):
         """Initialize the unified intelligence engine."""
         self.constitutional_engine = ConstitutionalEngine()
         self.workflow_detector = WorkflowDetector()
@@ -79,7 +81,10 @@ class UnifiedIntelligenceEngine:
         pattern = self.workflow_detector.detect(user_input)
 
         # 2. Apply constitutional validation
-        compliance = await self.constitutional_engine.validate(user_input, pattern)
+        compliance = await self.constitutional_engine.analyze_compliance_async(
+            user_input,
+            {"detected_pattern": pattern, "context": context},
+        )
 
         # 3. Enhance with Mangle reasoning (if code-related)
         mangle_insights = await self.mangle_bridge.get_insights(user_input, pattern)
@@ -112,10 +117,13 @@ class UnifiedIntelligenceEngine:
         self, pattern: str, compliance: dict, mangle_insights: dict
     ) -> list:
         """Generate actionable recommendations based on analysis."""
+        compliance = compliance or {}
+        mangle_insights = mangle_insights or {}
         recommendations = []
 
         # Constitutional recommendations
-        if compliance.get("score", 1.0) < 0.75:
+        compliance_score = compliance.get("overall_score", 1.0)
+        if compliance_score < 0.75:
             recommendations.append(
                 {
                     "type": "constitutional",
@@ -152,7 +160,7 @@ class UnifiedIntelligenceEngine:
             )
 
         # Mangle-based recommendations
-        if mangle_insights.get("code_quality_issues"):
+        if mangle_insights and mangle_insights.get("code_quality_issues"):
             recommendations.append(
                 {
                     "type": "code_quality",
@@ -166,7 +174,7 @@ class UnifiedIntelligenceEngine:
 
     async def validate_constitutional_compliance(self, code_or_spec: str) -> dict:
         """Quick constitutional compliance check."""
-        return await self.constitutional_engine.analyze_compliance(code_or_spec)
+        return await self.constitutional_engine.analyze_compliance_async(code_or_spec)
 
     async def ask_code_question(self, question: str) -> dict:
         """Ask a question about the codebase using Mangle reasoning."""
@@ -180,4 +188,4 @@ class UnifiedIntelligenceEngine:
 
     def get_constitutional_articles(self) -> dict:
         """Get the SDD constitutional framework."""
-        return self.constitutional_engine.get_articles()
+        return self.constitutional_engine.get_all_articles()

--- a/src/unified_intelligence/constitutional_engine.py
+++ b/src/unified_intelligence/constitutional_engine.py
@@ -1,13 +1,8 @@
-"""
-Constitutional Compliance Engine
+"""Constitutional compliance engine helpers."""
 
-Implements SDD constitutional principle validation and guidance:
-- Nine constitutional articles from SDD methodology
-- Compliance scoring and reporting
-- Principle-specific guidance and recommendations
-- Advisory-only operation for seamless integration
-"""
+from __future__ import annotations
 
+import asyncio
 from enum import Enum
 
 
@@ -461,3 +456,10 @@ class ConstitutionalEngine:
             lines.append("")
 
         return "\n".join(lines)
+
+    async def analyze_compliance_async(
+        self, text: str, context: dict | None = None
+    ) -> dict:
+        """Asynchronously analyze constitutional compliance."""
+
+        return await asyncio.to_thread(self.analyze_compliance, text, context)

--- a/src/unified_intelligence/copilot_enhancer.py
+++ b/src/unified_intelligence/copilot_enhancer.py
@@ -165,6 +165,59 @@ class CopilotEnhancer:
             logger.warning(f"Copilot enhancement failed: {e}")
             return self._error_response(str(e))
 
+    def generate_guidance(
+        self,
+        user_input: str,
+        pattern: str | None = None,
+        compliance: dict[str, Any] | None = None,
+        mangle_insights: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Create consolidated guidance for the unified intelligence engine."""
+
+        context = {
+            "detected_pattern": pattern,
+            "constitutional_compliance": compliance,
+            "mangle_insights": mangle_insights,
+        }
+
+        enhancement = self.enhance_response(user_input, context=context)
+
+        highlights: list[dict[str, Any]] = []
+        if compliance:
+            overall_score = compliance.get("overall_score")
+            if overall_score is not None:
+                highlights.append(
+                    {
+                        "type": "constitutional_score",
+                        "value": overall_score,
+                        "status": "ok" if overall_score >= 0.75 else "attention",
+                    }
+                )
+
+        if mangle_insights:
+            highlights.append(
+                {
+                    "type": "mangle_availability",
+                    "value": mangle_insights.get("available"),
+                    "detail": mangle_insights.get("analysis_type")
+                    or mangle_insights.get("message"),
+                }
+            )
+
+        if pattern:
+            highlights.append(
+                {
+                    "type": "workflow_pattern",
+                    "value": pattern,
+                }
+            )
+
+        return {
+            "enhancement": enhancement,
+            "highlights": highlights,
+            "pattern": pattern,
+        }
+
     def _detect_workflow_pattern(self, user_input: str) -> str | None:
         """Detect SDD workflow pattern from user input."""
         user_lower = user_input.lower()

--- a/src/unified_intelligence/mangle_bridge.py
+++ b/src/unified_intelligence/mangle_bridge.py
@@ -1,13 +1,8 @@
-"""
-Mangle Reasoning Bridge
+"""Mangle Reasoning Bridge abstractions."""
 
-Provides integration with Mangle deductive reasoning engine:
-- Code knowledge graph generation and querying
-- Logical inference and fact-based reasoning
-- Question answering using deductive database
-- Advisory-only operation for seamless integration
-"""
+from __future__ import annotations
 
+import asyncio
 import logging
 from pathlib import Path
 from typing import Any
@@ -23,12 +18,19 @@ class MangleBridge:
     when Mangle is not available or encounters errors.
     """
 
-    def __init__(self, workspace_path: str | None = None):
+    def __init__(
+        self,
+        workspace_root: str | None = None,
+        mangle_executable: str | None = None,
+    ) -> None:
         """Initialize the Mangle bridge with optional workspace path."""
-        self.workspace_path = Path(workspace_path) if workspace_path else Path.cwd()
+
+        self.workspace_path = Path(workspace_root) if workspace_root else Path.cwd()
+        self.mangle_executable = mangle_executable or "mangle"
         self.mangle_available = False
         self.fact_generator = None
         self.reasoner = None
+        self._initialized = False
 
         # Try to initialize Mangle components
         self._initialize_mangle()
@@ -47,15 +49,33 @@ class MangleBridge:
             logger.info("Mangle reasoning engine initialized successfully")
 
         except ImportError as e:
-            logger.warning(f"Mangle components not available: {e}")
+            logger.warning("Mangle components not available: %s", e)
             self.mangle_available = False
-        except Exception as e:
-            logger.warning(f"Failed to initialize Mangle: {e}")
+        except Exception as e:  # pragma: no cover - defensive guard
+            logger.warning("Failed to initialize Mangle: %s", e)
             self.mangle_available = False
+        finally:
+            self._initialized = True
+
+    async def initialize(self) -> None:
+        """Asynchronously initialize Mangle components if needed."""
+
+        if self._initialized and self.mangle_available:
+            return
+
+        await asyncio.to_thread(self._initialize_mangle)
 
     def is_available(self) -> bool:
         """Check if Mangle reasoning is available."""
         return self.mangle_available
+
+    async def get_insights(
+        self, question: str, pattern: str | None = None
+    ) -> dict[str, Any]:
+        """Asynchronously generate code insights using Mangle reasoning."""
+
+        del pattern  # Currently unused but retained for compatibility
+        return await asyncio.to_thread(self.generate_code_insights, question)
 
     def generate_code_insights(self, question: str) -> dict[str, Any]:
         """
@@ -457,3 +477,8 @@ class MangleBridge:
                 validation["issues"].append(f"Basic operation failed: {e}")
 
         return validation
+
+    async def ask_question(self, question: str) -> dict[str, Any]:
+        """Asynchronously query the codebase using Mangle reasoning."""
+
+        return await asyncio.to_thread(self.query_codebase, question)

--- a/tests/unified_intelligence/test_unified_engine.py
+++ b/tests/unified_intelligence/test_unified_engine.py
@@ -1,0 +1,65 @@
+import asyncio
+
+from src.unified_intelligence import UnifiedIntelligenceEngine
+
+
+class FakeMangleBridge:
+    """Test double emulating the asynchronous Mangle bridge contract."""
+
+    def __init__(self):
+        self.initialized = False
+        self.questions_asked: list[str] = []
+
+    async def initialize(self) -> None:  # pragma: no cover - simple state update
+        self.initialized = True
+
+    async def get_insights(self, user_input: str, pattern: str | None = None) -> dict:
+        return {
+            "available": True,
+            "question": user_input,
+            "pattern": pattern,
+            "analysis_type": "test_double",
+            "code_quality_issues": False,
+            "quality_recommendations": [],
+        }
+
+    async def ask_question(self, question: str) -> dict:
+        self.questions_asked.append(question)
+        return {"available": True, "question": question, "answer": "stub"}
+
+
+def test_enhance_interaction_with_fake_mangle() -> None:
+    async def _run() -> None:
+        engine = UnifiedIntelligenceEngine()
+        engine.mangle_bridge = FakeMangleBridge()
+        engine._initialized = False  # ensure we invoke fake initialization
+
+        result = await engine.enhance_interaction(
+            "Create a new feature plan for telemetry"
+        )
+
+        assert result["mangle_insights"]["available"] is True
+        assert result["enhanced_guidance"]["enhancement"]["enhanced"] is True
+        assert "overall_score" in result["constitutional_compliance"]
+        assert result["recommendations"]  # expect at least one recommendation branch
+
+    asyncio.run(_run())
+
+
+def test_ask_code_question_uses_fake_bridge() -> None:
+    async def _run() -> None:
+        engine = UnifiedIntelligenceEngine()
+        fake_bridge = FakeMangleBridge()
+        engine.mangle_bridge = fake_bridge
+        engine._initialized = False
+
+        answer = await engine.ask_code_question(
+            "What tests cover the workflow detector?"
+        )
+
+        assert answer["available"] is True
+        assert fake_bridge.questions_asked == [
+            "What tests cover the workflow detector?"
+        ]
+
+    asyncio.run(_run())


### PR DESCRIPTION
## Summary
- align `UnifiedIntelligenceEngine` with the concrete async methods exposed by the constitutional, Mangle, and Copilot components
- extend the Mangle bridge and constitutional engine with lightweight async adapters and add Copilot guidance aggregation
- add regression coverage that exercises the unified engine flow with a fake Mangle bridge

## What changed / Why
- wiring in `UnifiedIntelligenceEngine` now uses `analyze_compliance_async`, the bridge async surface, and the new Copilot guidance helper so the engine awaits real coroutines instead of synchronous callables. This prevents runtime `TypeError` and missing attribute errors.
- `MangleBridge` gained support for the previously-expected constructor signature plus async `initialize`, `get_insights`, and `ask_question` shims so the engine can await it safely.
- `ConstitutionalEngine` exposes an async adapter via `asyncio.to_thread`, eliminating the incorrect awaiting of synchronous methods.
- `CopilotEnhancer` now provides `generate_guidance` so the engine consumes a stable interface, and the new regression test verifies the full `enhance_interaction` path with a fake bridge to guard against future regressions.

## Risks
- Minimal: changes are confined to the unified intelligence stack and a new test module. Async wrappers rely on `asyncio.to_thread`, which requires a running event loop but mirrors prior expectations.

## Test coverage
- Added `tests/unified_intelligence/test_unified_engine.py` to confirm the unified engine initializes with a fake bridge, produces guidance, and proxies code questions.

## Verification
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/unified_intelligence -rs`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/runtime` *(fails on existing FastAPI response model annotations during collection)*
- `pre-commit run --all-files` *(fails due to numerous pre-existing repo-wide lint/type issues; reverted side effects)*

## Runtime impact
- None expected; async wrappers defer to existing synchronous logic and maintain current performance characteristics. Initialization remains lazy and only falls back to background threads when necessary.

## Observability
- No telemetry shape changes. The engine continues to emit existing structures; highlights emitted by `generate_guidance` are purely local data for response composition.

## Rollback
- Revert commit 99f04a931e78fed951aea109a68351643837de7f to restore the previous synchronous interfaces and remove the added test.

------
https://chatgpt.com/codex/tasks/task_e_68e59f00645c8328b1315fa79a274cc6